### PR TITLE
fix(audio): integer I2S PIO divider - kills the LRCK/MCLK sample-slip click

### DIFF
--- a/bsp/audio/audio_i2s_duplex.c
+++ b/bsp/audio/audio_i2s_duplex.c
@@ -76,12 +76,15 @@ void audio_i2s_duplex_init(uint32_t sample_rate) {
     // clk_sys, so at 250 MHz it is 250e6/61 = 4.0984 MHz (not 4.096) -> the codec's
     // MCLK-direct DAC consumes at 4.0984e6/256 = 16009 Hz. If LRCK were set to the
     // nominal 16000 Hz the DAC would slip ~9 samples/s -> an audible ~9 Hz tick
-    // (verified on-hardware: +/-9.2 Hz sidebands on the 1 kHz carrier). Deriving the
-    // clkdiv from the SAME integer `ticks` makes LRCK == MCLK/256 exactly, so data
-    // in == data out and the slip vanishes. clkdiv = clk/(96 * MCLK/256) = ticks*8/3.
-    // Net pitch error vs nominal is +0.06 % (16009 vs 16000 Hz) = inaudible.
-    float div = (float)(8u * ticks) / 3.0f;
-    pio_sm_set_clkdiv(DPX_PIO, DPX_SM, div);
+    // (verified on-hardware: +/-9.2 Hz sidebands on the 1 kHz carrier). Deriving
+    // the clkdiv from the SAME integer `ticks` is necessary but NOT sufficient:
+    // the old 96*fs PIO program needed clkdiv = 8*ticks/3, and unless ticks is
+    // divisible by 3 the 8.8-bit fractional divider rounds — LRCK then drifts
+    // against MCLK by one full sample every ~0.84 s at 48 kHz (~7.8 s at 16 kHz)
+    // and the MCLK-clocked codec audibly clicks on each slip (bench-measured,
+    // root-caused 2026-07-24). The PIO program now runs 4 cycles/bit = 128*fs,
+    // so the divider is the INTEGER 2*ticks and LRCK == MCLK/256 EXACTLY.
+    pio_sm_set_clkdiv_int_frac(DPX_PIO, DPX_SM, (uint16_t)(2u * ticks), 0);
     pio_sm_set_enabled(DPX_PIO, DPX_SM, true);
 }
 

--- a/bsp/audio/i2s_duplex.pio
+++ b/bsp/audio/i2s_duplex.pio
@@ -1,8 +1,14 @@
 ; bsp/audio/i2s_duplex.pio — full-duplex I2S, MCU supplies all clocks (codec=slave).
 ; 16 bits/channel, MSB first, 32-bit frame [L16|R16]. side-set bit0=LRCK, bit1=BCLK.
 ; OUT pin = SPK_DIN (GPIO5, DAC), IN pin = SPK_DOUT (GPIO4, ADC).
-; Per counted bit: out on BCLK-low, sample (in) on BCLK-high (rising edge), count on
-; BCLK-low -> 3 PIO instr/bit, 1 BCLK pulse/bit, 32 bits/frame => PIO clock = 96*fs.
+; Per counted bit: out on BCLK-low (2 cycles), sample (in) on BCLK-high (rising
+; edge), count on BCLK-high -> 4 PIO CYCLES/bit, 32 bits/frame => PIO clock =
+; 128*fs, so the SM divider is the INTEGER 2*ticks (ticks = clk_sys/(256*fs),
+; the MCLK divider). CRITICAL: the previous 3-cycle/bit version needed the
+; FRACTIONAL divider 8*ticks/3, whose 8.8-bit rounding made LRCK drift against
+; MCLK by one audio sample every ~0.84 s at 48 kHz (~7.8 s at 16 kHz) — the
+; MCLK-clocked codec slipped a sample each time: a metronomic audible click
+; (bench-measured and root-caused 2026-07-24). Keep cycles/bit a power of two.
 ;
 ; ALIGNMENT KNOB (bring-up risk, same as the proven RX program): if RX peaks stay at
 ; the floor while the mic is driven, move the `in pins,1` to the other BCLK phase, or
@@ -11,18 +17,18 @@
 .side_set 2
 
 .wrap_target
-    set x, 14            side 0b00   ; LEFT: LRCK=0, BCLK=0
+    set x, 14            side 0b00       ; LEFT: LRCK=0, BCLK=0
 left_bit:
-    out pins, 1          side 0b00   ; BCLK low: present DAC bit
-    in pins, 1           side 0b10   ; BCLK high: latch ADC bit (rising edge)
-    jmp x-- left_bit     side 0b00   ; BCLK low: advance
-    out pins, 1          side 0b00   ; 16th DAC bit (left)
-    in pins, 1           side 0b10   ; 16th ADC bit (left)
-    set x, 14            side 0b01   ; RIGHT: LRCK=1, BCLK=0
+    out pins, 1          side 0b00 [1]   ; BCLK low x2: present DAC bit
+    in pins, 1           side 0b10       ; BCLK high: latch ADC bit (rising)
+    jmp x-- left_bit     side 0b10       ; BCLK high: advance
+    out pins, 1          side 0b00 [1]   ; 16th DAC bit (left), low x2
+    in pins, 1           side 0b10       ; 16th ADC bit (left)
+    set x, 14            side 0b01       ; RIGHT: LRCK=1, BCLK=0
 right_bit:
-    out pins, 1          side 0b01
-    in pins, 1           side 0b11   ; BCLK high, LRCK high: sample
-    jmp x-- right_bit    side 0b01
-    out pins, 1          side 0b01   ; 16th DAC bit (right)
-    in pins, 1           side 0b11   ; 16th ADC bit (right)
+    out pins, 1          side 0b01 [1]
+    in pins, 1           side 0b11       ; BCLK high, LRCK high: sample
+    jmp x-- right_bit    side 0b11
+    out pins, 1          side 0b01 [1]   ; 16th DAC bit (right), low x2
+    in pins, 1           side 0b11       ; 16th ADC bit (right)
 .wrap


### PR DESCRIPTION
## The bug

The 3-cycle/bit i2s_duplex PIO program requires clkdiv = 8*ticks/3. Unless `ticks` divides by 3, the 8.8-bit fractional divider rounds, LRCK drifts against MCLK, and the MCLK-clocked NAU88C10 slips one full sample every ~7.8 s at 16 kHz (~0.84 s at 48 kHz): an audible metronomic click, present since bring-up.

## Who is affected

Everyone using `audio_i2s_duplex` — this is not specific to one sample rate or app. `board_init()` sets clk_sys = 250 MHz, so `ticks = clk_sys / (256*fs)` works out to:

| config | ticks | 8*ticks/3 | integer? | click period |
|---|---|---|---|---|
| 16 kHz (BSP default: hello_audio, wilidoro tones) | 61 | 162.667 | no | ~7.8 s |
| 48 kHz | 20 | 53.333 | no | ~0.84 s |

The only escapees are lucky combinations where `ticks % 3 == 0` (e.g. the Pico SDK's stock 150 MHz at 16 kHz, ticks = 36 — a configuration no BSP app uses). At the BSP's 250 MHz, every duplex-audio app clicks; at 16 kHz it is just slow enough (~7.8 s) to pass for random noise.

Scope note: the change touches only the i2s_duplex program on its own state machine (per-SM divider). Nothing else — LED/PDM/radio PIO programs, HSTX/DVI graphics, clk_sys — is affected; bit depth is irrelevant to the mechanism.

## Evidence

Bench root-caused via line-out recording analysis (fw2-audio-demo project): measured click periods of 838.8 +/- 0.4 ms at 48,828 Hz and 7,804 ms at 16,009 Hz match the divider-rounding prediction to <0.1% at both rates. The click survives with zero code executing (pure DMA/PIO/codec), and disappears with this fix.

## The fix

The PIO program now runs 4 cycles/bit (PIO clock 128*fs) so the SM divider is the INTEGER 2*ticks at any rate - LRCK == MCLK/256 exactly, forever. Verified click-free at 16 kHz and 48 kHz via line-out captures (0 events vs 2/14 clicks in identical baseline windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
