### PR TITLE
fix: clamp capture DMA to its buffers; keep IRQs live during agentio RTT streaming

### DIFF
--- a/bsp/agentio/agentio.c
+++ b/bsp/agentio/agentio.c
@@ -96,6 +96,34 @@ static void reply(const char *s)
     SEGGER_RTT_Write(AGENTIO_RTT_CHANNEL, s, (unsigned)strlen(s));
 }
 
+/* Write a payload larger than the RTT up buffer WITHOUT blocking inside
+ * SEGGER_RTT_Write. That call holds SEGGER_RTT_LOCK (interrupts off) for the
+ * whole transfer, so when the payload exceeds the buffer it spins with IRQs
+ * masked until the host drains — and any DMA whose rearm lives in an IRQ
+ * handler (e.g. audio_capture's ping-pong) keeps chaining un-rearmed and
+ * marches its write address through RAM (root-caused on FW2 2026-07-27:
+ * capture DMA sprayed BSS from s_buf to the top of SRAM, corrupting this
+ * module's own response buffer mid-transfer). Chunking to the space that is
+ * free RIGHT NOW means each SEGGER_RTT_Write completes without ever spinning
+ * under the lock, and interrupts breathe between chunks. If the host stops
+ * draining for 3 s the remainder is dropped so the UI loop never hangs. */
+static void rtt_write_yielding(const void *data, unsigned len)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    uint32_t stall_start = time_us_32();
+    while (len) {
+        unsigned avail = SEGGER_RTT_GetAvailWriteSpace(AGENTIO_RTT_CHANNEL);
+        if (!avail) {
+            if (time_us_32() - stall_start > 3000000u) return;   /* host gone */
+            continue;
+        }
+        unsigned k = avail < len ? avail : len;
+        SEGGER_RTT_Write(AGENTIO_RTT_CHANNEL, p, k);   /* fits: never blocks */
+        p += k; len -= k;
+        stall_start = time_us_32();
+    }
+}
+
 /* Split `line` on single spaces into up to `max` tokens. Returns the count. */
 static int split(char *line, char **argv, int max)
 {
@@ -219,14 +247,14 @@ static void do_capture(int surface, int x, int y, int w, int h, int scale)
     put_u16(&hdr[10], (uint16_t)out_w);
     put_u16(&hdr[12], (uint16_t)out_h);
     put_u32(&hdr[14], total);
-    SEGGER_RTT_Write(AGENTIO_RTT_CHANNEL, hdr, sizeof hdr);
+    rtt_write_yielding(hdr, sizeof hdr);
 
-    /* Pass 2: stream. The up buffer blocks when full, so this returns only
-     * once the host has drained every byte. */
+    /* Pass 2: stream, yielding between chunks so interrupts stay live while
+     * the host drains (see rtt_write_yielding). */
     for (int r = 0; r < out_h; r++) {
         read_row(surface, x, y + r * scale, out_w, scale);
         size_t n = agentio_rle_encode(s_row, (size_t)out_w, s_enc, sizeof s_enc);
-        SEGGER_RTT_Write(AGENTIO_RTT_CHANNEL, s_enc, (unsigned)n);
+        rtt_write_yielding(s_enc, (unsigned)n);
     }
 }
 

--- a/bsp/audio/audio_capture.c
+++ b/bsp/audio/audio_capture.c
@@ -8,7 +8,13 @@
 #include "hardware/irq.h"
 #include <stddef.h>
 
-static uint32_t s_buf[2][AUDIO_CAPTURE_BLOCK_FRAMES];
+// aligned + write-ring (see start_channel): if the rearm IRQ is ever starved
+// (e.g. a long IRQs-off region elsewhere), the chained ping-pong would keep
+// running with an un-reset write address and march through RAM — bench-proven
+// 2026-07-27: it sprayed BSS from here to the top of SRAM. The hardware ring
+// clamps each channel inside its own block no matter what.
+static uint32_t __attribute__((aligned(sizeof(uint32_t) * AUDIO_CAPTURE_BLOCK_FRAMES)))
+    s_buf[2][AUDIO_CAPTURE_BLOCK_FRAMES];
 static int s_dma[2];
 static volatile int s_done = -1;    // index of a freshly filled buffer, or -1
 static volatile bool s_ready = false;
@@ -20,6 +26,12 @@ static void start_channel(int ch, int other_ch, uint32_t *dst) {
     channel_config_set_write_increment(&c, true);
     channel_config_set_dreq(&c, audio_i2s_duplex_rx_dreq());
     channel_config_set_chain_to(&c, other_ch);   // ping-pong
+    // Wrap the WRITE address at the block boundary (buffer is aligned to its
+    // size above): a missed rearm then loops inside the block instead of
+    // marching into the rest of RAM.
+    _Static_assert((sizeof s_buf[0] & (sizeof s_buf[0] - 1)) == 0,
+                   "capture block must be a power of two for the DMA ring");
+    channel_config_set_ring(&c, true, __builtin_ctz(sizeof s_buf[0]));
     dma_channel_configure(ch, &c, dst, audio_i2s_duplex_rxf(),
                           AUDIO_CAPTURE_BLOCK_FRAMES, false);
 }


### PR DESCRIPTION
Two small fixes for the same hazard class: code that masks interrupts for longer than one audio block can silently corrupt RAM. One fix removes the consequence, the other removes the largest in-tree trigger.

## 1. `audio_capture`: a starved rearm IRQ lets the DMA write past its buffer — silent RAM corruption

The two capture channels ping-pong via `CHAIN_TO` in **hardware**, but each channel's write-address rearm lives in a `DMA_IRQ_0` handler — **software**. The chain never pauses; the rearm can. If interrupts are masked on the servicing core for longer than one block (5.2 ms at 48 kHz, 16 ms at 16 kHz), the chain re-triggers a channel whose write address still points past its block end, and every subsequent block pushes it further. Bench-measured on FW2: the write address marched from `s_buf` through the rest of BSS to the top of SRAM, overwriting ~196 KB of live state with I2S RX samples.

This is not an exotic condition. Ordinary code masks IRQs for multiple milliseconds while capture runs:

- **flash writes** — `flash_range_erase`/`flash_range_program` run with IRQs disabled (sector erase is tens of ms); any app that saves settings while capturing audio arms this
- long critical sections in other drivers (e.g. a blocking `SEGGER_RTT_Write` holds `SEGGER_RTT_LOCK` = IRQs off — see fix 2)
- any long-running ISR on the same core

The symptom is corruption of *unrelated* memory, discovered far from the cause — the worst kind of bug to hand a BSP user.

**Fix:** align each block buffer to its size and enable the channel's hardware write-address ring (`channel_config_set_ring`). A missed rearm now wraps inside its own block; escape is impossible by construction. Zero cost on the normal path (config-time registers only); a `_Static_assert` guards the power-of-two requirement.

## 2. `agentio`: streaming a capture response holds `SEGGER_RTT_LOCK` (IRQs off) for the whole transfer

`SEGGER_RTT_Write` on a `BLOCK_IF_FIFO_FULL` channel takes the RTT lock — interrupts masked — and keeps it while spinning for the host to drain. Any response larger than the 4 KB up buffer (every non-trivial `CAP`) therefore masks IRQs for hundreds of milliseconds per transfer, starving audio/display/input interrupts on that core and directly arming hazard #1 in any app that runs the harness alongside capture.

**Fix:** `rtt_write_yielding()` writes only what currently fits, so each `SEGGER_RTT_Write` completes without spinning under the lock and IRQs breathe between chunks. A 3 s no-progress timeout drops the remainder if the host disappears, so the target app loop can never hang on a vanished host.

## Verification

On FW2 hardware: DMA `WRITE_ADDR` register dumps confirm the capture channels stay clamped inside their blocks under deliberate IRQ starvation, and full-screen agentio captures complete with interrupts live (core-1 audio unaffected throughout). Both changes are running in a full application (audio pipeline + LCD UI + agentio) with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
