### PR TITLE
input: power-zone requests over the coprocessor link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,40 @@ BSP was harvested from. They are also recorded in `docs/hardware/facts.md`.
     2026-07-26, caveats included:
     `docs/superpowers/findings/2026-07-26-gpio-vref-e2e.md`.
 
+## Peripheral power zones — request rails BEFORE touching hardware
+
+The board's power sequencer boots with most peripheral rails **OFF**
+(audio codec, CAN, radios, RGB LEDs, the analog subsystem, ...). A driver
+that reads garbage, NAKs, or produces silence is very often an unpowered
+rail, not a code bug — check power before debugging the driver. The
+boot-on set is sequencer-firmware-defined and can change between firmware
+versions: **never rely on it; request what you need, every time.**
+
+The pattern for any app using a peripheral (see `docs/drivers/power.md`
+for the full zone map, per-zone cautions, and the protocol):
+
+```c
+uartkbd_init();                                       // link to the sequencer
+picpwr_keep_awake(picpwr_zone_bit(PICPWR_ZONE_AUDIO)); // or _CAN, _RGB_LEDS, ...
+// rails take ~1 s to apply; THEN init the peripheral
+...
+while (true) {
+    uartkbd_task();
+    picpwr_task();     // re-asserts your rails if the sequencer drops them
+    ...
+}
+```
+
+Rules that cost real bench time:
+
+- Request rails **before** initializing peripherals on them; a rail
+  rising mid-session can glitch a shared I2C bus (run bus recovery after
+  a rail apply if the bus was live during it).
+- Read the zone map before switching anything **off** — some zones blank
+  the display, drop your debug probe, or risk filesystem corruption.
+- Never set mask bits above zone 17; the API strips them (they are
+  reserved — `docs/drivers/power.md`).
+
 ## "GPIO" is ambiguous on this board — ASK which one
 
 **When a request mentions GPIO, stop and ask the user which kind before writing

--- a/bsp/CMakeLists.txt
+++ b/bsp/CMakeLists.txt
@@ -51,6 +51,8 @@ add_library(freewili2_bsp STATIC
     keyboard/fw2kb_hidmap.c
     input/uartkbd_parse.c
     input/uartkbd.c
+    input/picpwr_frame.c
+    input/picpwr.c
     usbhost/usb_core.c
     usbhost/usb_hcd.c
     usbhost/usb_hub.c

--- a/bsp/input/picpwr.c
+++ b/bsp/input/picpwr.c
@@ -1,0 +1,122 @@
+/* picpwr — see picpwr.h. */
+#include "picpwr.h"
+#include "uartkbd.h"
+#include "pico/stdlib.h"
+
+/* One command per rail walk: the device applies a mask as a staggered
+ * walk (~1 s) and does not parse the link while walking. Commands are
+ * applied unconditionally even when nothing changed, so every send costs
+ * a walk — space them out and never stack retries. */
+#define PICPWR_SPACING_MS 1500u
+
+static picpwr_cfg_t    s_cache;
+static absolute_time_t s_last_send;
+static bool            s_sent_any;
+
+bool picpwr_rails(uint32_t *rails_out)
+{
+    uint8_t payload[20];
+    if (!uartkbd_status_raw(payload)) return false;
+    *rails_out = picpwr_rails_decode(payload);
+    return true;
+}
+
+/* Rail state accepted only when two DISTINCT status frames agree —
+ * gated on the frame counter, not wall time, because frames arrive
+ * about once a second and two reads of the same cached frame always
+ * "agree". A single stale or unsettled snapshot echoed back into an
+ * awake mask would switch off every rail it failed to report, so one
+ * frame is never trusted alone. */
+static bool rails_stable(uint32_t *rails_out)
+{
+    uint32_t a, b;
+    if (!picpwr_rails(&a)) return false;
+    uint32_t seen = uartkbd_frames();
+    absolute_time_t until = make_timeout_time_ms(2500);
+    while (uartkbd_frames() == seen) {           /* wait for a fresh frame */
+        if (time_reached(until)) return false;
+        uartkbd_task();
+        sleep_ms(10);
+    }
+    if (!picpwr_rails(&b)) return false;
+    if (b != a) return false;
+    *rails_out = a;
+    return true;
+}
+
+bool picpwr_send(const picpwr_cfg_t *cfg)
+{
+    if (s_sent_any &&
+        absolute_time_diff_us(s_last_send, get_absolute_time())
+            < (int64_t)PICPWR_SPACING_MS * 1000)
+        return false;
+    /* Clamp to the rail range no matter what the caller passed: the
+     * reserved bits are not part of this API's contract in either
+     * direction. One of the status indications for those lines also
+     * reads back high while the correct commanded value is 0, so any
+     * requested-vs-actual comparison must use the same clamp. */
+    picpwr_cfg_t clamped = *cfg;
+    clamped.awake &= PICPWR_ZONE_MASK_ALL;
+    clamped.sleep &= PICPWR_ZONE_MASK_ALL;
+    uint8_t frame[PICPWR_FRAME_LEN];
+    picpwr_frame_build(frame, &clamped);
+    (void)uartkbd_cmd_send(frame, sizeof frame);
+    s_cache = clamped;
+    s_last_send = get_absolute_time();
+    s_sent_any = true;
+    return true;
+}
+
+bool picpwr_ensure_awake(uint32_t zone_bits)
+{
+    zone_bits &= PICPWR_ZONE_MASK_ALL;
+    uint32_t rails;
+    if (!rails_stable(&rails)) return false;
+    rails &= PICPWR_ZONE_MASK_ALL;
+    if ((rails & zone_bits) == zone_bits) return true;
+    picpwr_cfg_t cfg = s_cache;
+    /* Rails come from live state ORed with the request — strictly
+     * additive, so no rail that currently reads as powered is ever
+     * cleared by this helper. picpwr_send() clamps to zones 1..17. */
+    cfg.awake = rails | zone_bits;
+    return picpwr_send(&cfg);
+}
+
+static uint32_t s_desired;
+
+bool picpwr_keep_awake(uint32_t zone_bits)
+{
+    zone_bits &= PICPWR_ZONE_MASK_ALL;
+    s_desired |= zone_bits;
+    return picpwr_ensure_awake(zone_bits);
+}
+
+void picpwr_task(void)
+{
+    if (!s_desired) return;
+    static uint32_t last_frame;
+    static uint32_t prev_rails;
+    static bool     missing;
+    uint32_t f = uartkbd_frames();
+    if (f == last_frame) return;         /* evaluate each frame once */
+    last_frame = f;
+    uint32_t rails;
+    if (!picpwr_rails(&rails)) return;
+    rails &= PICPWR_ZONE_MASK_ALL;
+    if ((rails & s_desired) == s_desired) {
+        missing = false;
+        return;
+    }
+    /* A kept rail reads off. Debounce: act only when two consecutive
+     * frames agree on the same rail state, so one stale or unsettled
+     * snapshot never triggers a send. The send rate limit additionally
+     * spaces re-asserts past the device's apply time. */
+    if (!missing || rails != prev_rails) {
+        missing = true;
+        prev_rails = rails;
+        return;
+    }
+    picpwr_cfg_t cfg = s_cache;
+    cfg.awake = rails | s_desired;
+    if (picpwr_send(&cfg)) missing = false;
+}

--- a/bsp/input/picpwr.h
+++ b/bsp/input/picpwr.h
@@ -1,0 +1,61 @@
+/*
+ * picpwr — power-zone control over the coprocessor link (uartkbd's UART).
+ * The coprocessor sequences every switched rail on the board; rails
+ * outside its boot subset stay off until an application requests them
+ * (the audio codec and CAN rails are the common casualties). Protocol:
+ * docs/drivers/power.md. Polled/foreground like the rest of this BSP;
+ * uartkbd_init() must have run first.
+ */
+#ifndef PICPWR_H
+#define PICPWR_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "picpwr_frame.h"
+
+/* Send a complete power configuration. All four fields go in one atomic
+ * write — the device has no partial form and no readback of the sleep or
+ * wake fields, so callers must always provide complete values. Any zone
+ * bit left clear in awake switches that rail OFF. Only zones 1..17 are
+ * expressible: mask bits above that are reserved-zero and this API
+ * clamps them out of every frame it sends (docs/drivers/power.md).
+ * Rate-limited: returns false without sending
+ * while a previous command's rail walk (~1 s, blocking on the device
+ * side) may still be running — retry later. The cfg is cached and seeds
+ * picpwr_ensure_awake(). */
+bool picpwr_send(const picpwr_cfg_t *cfg);
+
+/* Live rail state decoded from the last status frame
+ * (zones 1..17 -> bits 0..16, high = powered). False until a status
+ * frame has been parsed. This is the only trustworthy source of rail
+ * state — other actors move rails without notice, so never trust a
+ * local cache for readback. */
+bool picpwr_rails(uint32_t *rails_out);
+
+/* Convenience: ensure the given rails are enabled, additively — no rail
+ * that currently reads as powered is ever cleared. Seeds the awake mask
+ * from LIVE rail state (never the cache), requiring two agreeing reads so
+ * an unsettled first frame cannot drop rails it failed to report; ORs in
+ * zone_bits; carries the cached sleep/wake fields. Comparisons and the
+ * sent mask cover zones 1..17 only — reserved bits are always zero.
+ * Returns true immediately when the rails already read as on; false when
+ * stable live state is unavailable or the rate limit is active (retry
+ * later). */
+bool picpwr_ensure_awake(uint32_t zone_bits);
+
+/* Like picpwr_ensure_awake(), and additionally remembers the rails so
+ * picpwr_task() re-asserts them if they later read as off (the device
+ * changes rails on its own: sleep/wake, USB attach/detach, watchdog).
+ * The primary entry point for applications: request the rails your
+ * peripherals need once at startup, poll picpwr_task() from the main
+ * loop, and the driver handles the rest. */
+bool picpwr_keep_awake(uint32_t zone_bits);
+
+/* Poll from the application's main loop (cheap; acts at most once per
+ * received status frame). Re-asserts rails registered with
+ * picpwr_keep_awake() when they read as off — debounced over two
+ * consecutive status frames and spaced by the send rate limit, so a
+ * single stale snapshot or an in-progress apply never causes a storm. */
+void picpwr_task(void);
+
+#endif /* PICPWR_H */

--- a/bsp/input/picpwr_frame.c
+++ b/bsp/input/picpwr_frame.c
@@ -1,0 +1,47 @@
+/* picpwr_frame — see picpwr_frame.h. */
+#include "picpwr_frame.h"
+
+size_t picpwr_frame_build(uint8_t out[PICPWR_FRAME_LEN],
+                          const picpwr_cfg_t *cfg)
+{
+    /* Mask bits above zone 17 are reserved and must be zero on the wire
+     * (docs/drivers/power.md). Enforced here so no caller can emit
+     * them. */
+    uint32_t awake = cfg->awake & PICPWR_ZONE_MASK_ALL;
+    uint32_t sleep = cfg->sleep & PICPWR_ZONE_MASK_ALL;
+    out[0]  = 0xB0;                              /* command sync */
+    out[1]  = 0x00;                              /* power-zone id */
+    out[2]  = (uint8_t)(awake >> 16);            /* masks go MSB first */
+    out[3]  = (uint8_t)(awake >> 8);
+    out[4]  = (uint8_t)(awake);
+    out[5]  = (uint8_t)(sleep >> 16);
+    out[6]  = (uint8_t)(sleep >> 8);
+    out[7]  = (uint8_t)(sleep);
+    out[8]  = cfg->wake;
+    out[9]  = cfg->wake2;
+    uint8_t sum = 0;
+    for (int i = 0; i < PICPWR_FRAME_LEN - 1; i++)
+        sum = (uint8_t)(sum + out[i]);
+    out[PICPWR_FRAME_LEN - 1] = sum;             /* additive 8-bit checksum */
+    return PICPWR_FRAME_LEN;
+}
+
+/* Rail-state positions inside the status payload: zone N reads from
+ * payload[byte] & mask, high = powered. */
+typedef struct { uint8_t byte, mask; } rail_pos_t;
+static const rail_pos_t RAILS[17] = {
+    { 3, 0x08 }, { 3, 0x10 }, { 3, 0x20 }, { 3, 0x40 }, { 3, 0x80 },
+    { 4, 0x01 }, { 4, 0x02 },
+    { 5, 0x02 }, { 5, 0x04 }, { 5, 0x08 }, { 5, 0x10 }, { 5, 0x20 },
+    { 6, 0x01 }, { 6, 0x02 }, { 6, 0x04 }, { 6, 0x10 },
+    { 7, 0x08 },
+};
+
+uint32_t picpwr_rails_decode(const uint8_t payload[20])
+{
+    uint32_t bits = 0;
+    for (int z = 0; z < 17; z++)
+        if (payload[RAILS[z].byte] & RAILS[z].mask)
+            bits |= 1u << z;
+    return bits;
+}

--- a/bsp/input/picpwr_frame.h
+++ b/bsp/input/picpwr_frame.h
@@ -1,0 +1,66 @@
+/*
+ * picpwr_frame — pure frame building and status decoding for the
+ * coprocessor power-zone command. Protocol: docs/drivers/power.md.
+ * No hardware includes — host-testable.
+ */
+#ifndef PICPWR_FRAME_H
+#define PICPWR_FRAME_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Power-zone command frame: sync, id, 8 payload bytes, checksum. */
+#define PICPWR_FRAME_LEN 11
+
+/* Zone assignments (zone N = mask bit N-1). Cautions and the boot-on
+ * set are documented in docs/drivers/power.md — read the zone map
+ * before switching anything OFF. */
+#define PICPWR_ZONE_SENSORS     1   /* sensors + an I/O expander */
+#define PICPWR_ZONE_DISPLAY     2   /* LCD panel + touch controller */
+#define PICPWR_ZONE_AUDIO       3   /* audio codec */
+#define PICPWR_ZONE_SUBGHZ      4   /* sub-GHz radio (shared rail; docs) */
+#define PICPWR_ZONE_WIFI_BT     5   /* Wi-Fi / Bluetooth module */
+#define PICPWR_ZONE_FPGA        6   /* FPGA + external memory */
+#define PICPWR_ZONE_SDCARD      7   /* microSD + bridge (unmount first) */
+#define PICPWR_ZONE_USB_HUB     8   /* USB hub (device-managed on attach) */
+#define PICPWR_ZONE_STATUS_LED  9   /* flag, not a rail: status-LED enable */
+#define PICPWR_ZONE_RGB_LEDS    10  /* addressable RGB LEDs */
+#define PICPWR_ZONE_ANALOG      11  /* DAC, ADC, op-amps */
+#define PICPWR_ZONE_AUX_DISPLAY 12  /* function not established; leave alone */
+#define PICPWR_ZONE_NFC_RFID    13  /* NFC + low-frequency RFID */
+#define PICPWR_ZONE_USB_SERIAL  14  /* USB-serial bridge (device-managed) */
+#define PICPWR_ZONE_CAN         15  /* CAN controller + transceiver */
+#define PICPWR_ZONE_DEBUG_PROBE 16  /* on-board debug probe */
+#define PICPWR_ZONE_COMPUTE     17  /* compute module — not usable here (docs) */
+
+/* Every expressible zone (1..17). Mask bits above this are RESERVED —
+ * MUST BE ZERO (docs/drivers/power.md). picpwr_frame_build() clears
+ * them from every frame; nothing in this API can set them. */
+#define PICPWR_ZONE_MASK_ALL 0x01FFFFu
+
+static inline uint32_t picpwr_zone_bit(int zone) {
+    return 1u << (zone - 1);
+}
+
+/* Full power configuration: one atomic write of all four fields. The
+ * device offers no readback of sleep/wake — callers must send complete
+ * values every time (see docs/drivers/power.md). Mask bits above zone 17
+ * are reserved-zero and stripped at serialization. */
+typedef struct {
+    uint32_t awake;   /* 24-bit zone mask: rails enabled while awake */
+    uint32_t sleep;   /* 24-bit zone mask: rails kept through sleep */
+    uint8_t  wake;    /* wake-source field */
+    uint8_t  wake2;   /* wake-source overflow field */
+} picpwr_cfg_t;
+
+/* Serialize a power-zone command frame into out[PICPWR_FRAME_LEN].
+ * Returns the frame length. */
+size_t picpwr_frame_build(uint8_t out[PICPWR_FRAME_LEN],
+                          const picpwr_cfg_t *cfg);
+
+/* Decode live rail state (zones 1..17 -> bits 0..16) from a 20-byte
+ * coprocessor status payload (the bytes between sync/id and checksum).
+ * High = rail powered. */
+uint32_t picpwr_rails_decode(const uint8_t payload[20]);
+
+#endif /* PICPWR_FRAME_H */

--- a/bsp/input/uartkbd.c
+++ b/bsp/input/uartkbd.c
@@ -157,3 +157,39 @@ void uartkbd_inject_set(uint16_t mask)
      * the flag stays raised and the frame goes out on a later task() call. */
     s_synth_pending = true;
 }
+
+bool uartkbd_status_raw(uint8_t out[20])
+{
+    return uartkbd_parse_status_raw(&s_parser, out);
+}
+
+bool uartkbd_cmd_send(const uint8_t *frame, size_t len)
+{
+    if (s_dma_chan < 0) return false;
+    /* Command gate: break wakes the receiver, then it announces readiness
+     * with a bare 0xC9. */
+    uart_set_break(UARTKBD_UART, true);
+    sleep_ms(2);
+    uart_set_break(UARTKBD_UART, false);
+    /* The activity byte can land mid-frame from the parser's point of
+     * view: scan raw ring bytes ahead of the parser, then drop whatever
+     * partial frame was in flight. Bytes consumed here are discarded —
+     * the next status frame refreshes every latched field. */
+    bool active = false;
+    absolute_time_t deadline = make_timeout_time_ms(500);
+    while (!active && !time_reached(deadline)) {
+        uint32_t wr = (uint32_t)(dma_channel_hw_addr(s_dma_chan)->write_addr
+                                 - (uintptr_t)s_ring) & (RING_SIZE - 1);
+        while (s_rd != wr) {
+            uint8_t b = s_ring[s_rd];
+            s_rd = (s_rd + 1) & (RING_SIZE - 1);
+            if (b == 0xC9) { active = true; break; }
+        }
+        tight_loop_contents();
+    }
+    uartkbd_parse_resync(&s_parser);
+    sleep_ms(5);
+    uart_write_blocking(UARTKBD_UART, frame, len);
+    sleep_ms(50);                       /* let the frame drain the link */
+    return active;
+}

--- a/bsp/input/uartkbd.h
+++ b/bsp/input/uartkbd.h
@@ -1,11 +1,13 @@
 /*
- * uartkbd — FW2 UART keyboard binding: UART1 @ 62500 8N1 on GPIO38 (TX,
- * claimed but never driven) / GPIO39 (RX). Frames arrive unsolicited;
- * RX-only. Polled — call uartkbd_task() every main-loop iteration.
+ * uartkbd — FW2 coprocessor link binding: UART1 @ 62500 8N1 on GPIO38
+ * (TX) / GPIO39 (RX). Status/button frames arrive unsolicited; command
+ * frames go out over the same pair via uartkbd_cmd_send(). Polled — call
+ * uartkbd_task() every main-loop iteration.
  */
 #ifndef UARTKBD_H
 #define UARTKBD_H
 
+#include <stddef.h>
 #include "uartkbd_parse.h"
 
 void     uartkbd_init(void);
@@ -16,6 +18,20 @@ uint8_t  uartkbd_flags(void);
 bool     uartkbd_charger(uartkbd_charger_t *out);
 uint32_t uartkbd_frames(void);
 uint32_t uartkbd_errors(void);
+
+/* Copy of the last valid status frame's 20-byte payload (false until one
+ * has arrived). Rail state decodes from it via picpwr_rails_decode(). */
+bool     uartkbd_status_raw(uint8_t out[20]);
+
+/* Send one command frame to the coprocessor over the same link. The
+ * receiver is command-gated: a UART break wakes it, a bare activity byte
+ * (0xC9) signals it is listening, then the frame goes out. Blocks up to
+ * ~560 ms worst case. Returns true when the activity byte was seen;
+ * false means the frame was sent after the wait timed out. Inbound bytes
+ * consumed while waiting are discarded and the frame parser resyncs.
+ * Callers must serialize sends and respect the device's post-command
+ * settling time (docs/drivers/power.md). */
+bool     uartkbd_cmd_send(const uint8_t *frame, size_t len);
 
 /* agentio: set the injected button mask (bit N = uartkbd_btn_t N held).
  * Works with or without a keyboard attached — uartkbd_init() primes the

--- a/bsp/input/uartkbd_parse.c
+++ b/bsp/input/uartkbd_parse.c
@@ -62,6 +62,8 @@ static void accept_frame(uartkbd_parser_t *p)
     p->flags = decode_flags(p->frame);
     memcpy(p->charger_raw, &p->frame[10], sizeof p->charger_raw);
     p->charger_valid = true;
+    memcpy(p->status_raw, &p->frame[2], sizeof p->status_raw);
+    p->status_valid = true;
     uint16_t nb = (uint16_t)(decode_buttons(p->frame) | p->inject_mask);
     if (!p->primed) {
         p->primed = true;
@@ -163,4 +165,17 @@ void uartkbd_parse_set_inject(uartkbd_parser_t *p, uint16_t mask)
 uint16_t uartkbd_parse_inject(const uartkbd_parser_t *p)
 {
     return p->inject_mask;
+}
+
+void uartkbd_parse_resync(uartkbd_parser_t *p)
+{
+    p->state = 0;
+    p->count = 0;
+}
+
+bool uartkbd_parse_status_raw(const uartkbd_parser_t *p, uint8_t out[20])
+{
+    if (!p->status_valid) return false;
+    memcpy(out, p->status_raw, sizeof p->status_raw);
+    return true;
 }

--- a/bsp/input/uartkbd_parse.h
+++ b/bsp/input/uartkbd_parse.h
@@ -96,6 +96,10 @@ typedef struct {
                                             * cancelled by real wire traffic */
     uint8_t  charger_raw[12];              /* frame bytes 10-21, last valid */
     bool     charger_valid;                /* any valid frame seen yet */
+    uint8_t  status_raw[20];               /* full payload (frame bytes 2-21),
+                                            * last valid — rail state lives
+                                            * here (see picpwr_rails_decode) */
+    bool     status_valid;
     bool     primed;                       /* first valid frame only latches
                                              * the baseline (coprocessor boot
                                              * frames carry garbage bits);
@@ -109,6 +113,13 @@ typedef struct {
 
 void     uartkbd_parse_init(uartkbd_parser_t *p);
 void     uartkbd_parse_byte(uartkbd_parser_t *p, uint8_t b);
+/* Drop any partially collected frame and return to sync hunt. Latched
+ * state (buttons, charger, status payload, counters) is preserved. */
+void     uartkbd_parse_resync(uartkbd_parser_t *p);
+/* Copy of the last valid frame's 20-byte payload; false until one has
+ * been seen. */
+bool     uartkbd_parse_status_raw(const uartkbd_parser_t *p,
+                                  uint8_t out[20]);
 bool     uartkbd_parse_next_event(uartkbd_parser_t *p, uartkbd_event_t *ev);
 uint16_t uartkbd_parse_buttons(const uartkbd_parser_t *p);
 uint8_t  uartkbd_parse_flags(const uartkbd_parser_t *p);

--- a/docs/drivers/power.md
+++ b/docs/drivers/power.md
@@ -106,7 +106,7 @@ zone 1 is bit 0 of the **last** byte and zone 17 is bit 0 of the first.
 | 9 | *Flag, not a rail*: status-LED enable | set | When set, the device's status LED shows heartbeat/activity and the application CPUs mirror it. Clear for LED-quiet operation. Safe either way; no rail moves |
 | 10 | Addressable RGB LEDs | no | — |
 | 11 | Analog subsystem (DAC, ADC, op-amps) | no | — |
-| 12 | No confirmed load | no | Leave in its default state. Not required for the LCD (verified: apps draw with it off); video-output involvement unverified |
+| 12 | No confirmed load | no | Leave in its default state. Verified not required for the LCD (apps draw with it off) or the video output (signal, sink detection and hotplug all unaffected with it off) |
 | 13 | NFC + low-frequency RFID | no | — |
 | 14 | USB-serial bridge | with USB cable | Managed automatically on cable attach/detach |
 | 15 | CAN controller + transceiver | no | — |

--- a/docs/drivers/power.md
+++ b/docs/drivers/power.md
@@ -1,0 +1,222 @@
+# Coprocessor power-zone protocol
+
+The board's power coprocessor sequences every switched rail. Rails
+outside its boot subset stay off until explicitly requested — notably the
+audio codec rail (zone 3) and the CAN rail (zone 15). The display CPU
+requests rails over the same UART link that carries the coprocessor's
+status/button frames (UART1, 62500 baud, 8N1, both directions). The
+display CPU is the only device that drives the coprocessor's receive
+line; there is no alternate control path.
+
+BSP support: `bsp/input/uartkbd.*` owns the link (RX parsing and command
+TX); `bsp/input/picpwr_frame.*` is the pure frame/mask logic
+(host-tested); `bsp/input/picpwr.*` is the application-facing API.
+
+## Command frame
+
+One shape in both directions:
+
+```
+SYNC | ID | payload[N] | CHK
+```
+
+- `SYNC` — one byte, `0xB0` for commands and replies.
+- `ID` — one byte; **payload length is implied by the id**. There is no
+  length field. Emitting the wrong payload size lands the checksum in the
+  wrong position and the frame is discarded.
+- `CHK` — 8-bit additive sum (wraparound) of every preceding byte,
+  including `SYNC` and `ID`. Not a CRC. No escaping — payload bytes may
+  legitimately equal a sync value.
+
+The unsolicited status frame differs: sync `0xBD`, id `0x1D`, 20-byte
+payload, same additive checksum.
+
+## Per-frame handshake (mandatory)
+
+The coprocessor's receiver is command-gated; skipping this sequence means
+the bytes are silently ignored:
+
+1. Assert a UART break for ~2 ms, then release it.
+2. Wait for a bare (unframed) activity byte `0xC9`, with a ~500 ms
+   fallback timeout — proceed anyway if it never arrives.
+3. Settle ~5 ms, transmit the frame, then allow ~50 ms before treating
+   the link as free.
+
+`0xC9` may arrive mid-frame from the RX parser's perspective. It must be
+intercepted ahead of the parser and any partially collected frame
+dropped (implemented inside `uartkbd_cmd_send()`).
+
+## Power-zone command (`ID 0x00`, payload 8 bytes)
+
+| Offset | Size | Field |
+|---|---|---|
+| 0–2 | 3 | awake mask — rails enabled now |
+| 3–5 | 3 | sleep mask — rails kept through sleep |
+| 6 | 1 | wake-source field |
+| 7 | 1 | wake-source overflow field |
+
+This is a single **atomic write of all four fields** — no partial form,
+no read-modify-write on the device, and the sleep/wake fields cannot be
+read back. Consequences:
+
+- Always send a **complete awake mask**: any zone bit left clear switches
+  that rail off (including the display rail).
+- Keep a cached copy of all four fields and send the full set every time.
+- Seed the awake mask's rail bits from **live status-frame state** (see
+  below), never from a local cache alone — other actors move rails
+  without notice.
+
+Worked example — zones 1–17 on, sleep/wake zeroed:
+
+```
+B0 00 01 FF FF 00 00 00 00 00 AF
+```
+
+(Checksum: the byte sum is 0x2AF; truncated to 8 bits = 0xAF.) Note the
+reserved bits above zone 17 are zero — that is the required form, not a
+simplification. Suitable as a smoke test only because it zeroes the sleep
+configuration.
+
+## Zone mask encoding
+
+24-bit field, most-significant byte first. Zone *N* is bit *N−1*, so
+zone 1 is bit 0 of the **last** byte and zone 17 is bit 0 of the first.
+
+- Zones 1–17 are switched rails (zone 9 excepted — a flag, see the map).
+- Bits above zone 17 are **RESERVED — MUST BE ZERO.** They reach board
+  control lines rather than switched rails, are not safely
+  software-controllable on current hardware revisions, and zero matches
+  the boot state. They are deliberately **not** exposed by the `picpwr`
+  API — it clamps every outgoing mask to zones 1–17. If software control
+  of one is ever needed it must be a separate, explicitly documented,
+  opt-in call gated on a board revision that supports it.
+
+## Zone map
+
+| Zone | Powers | On at boot? | Application notes |
+|---|---|---|---|
+| 1 | Motion/magnetic/humidity/light sensors + an I/O expander | yes | The expander serves more than the sensors — switching off has a wide blast radius |
+| 2 | LCD panel + touch controller | yes | Off = blank screen, no touch |
+| 3 | Audio codec | no | — |
+| 4 | Sub-GHz radio + LoRa module (shared rail) | no | The sub-GHz radio is usable; the LoRa module is held in reset by a reserved control line and is **not** usable through this interface |
+| 5 | Wi-Fi / Bluetooth module | no | — |
+| 6 | FPGA + its external memory | no | — |
+| 7 | microSD card + bridge | yes | Unmount before switching off — corruption risk |
+| 8 | USB hub | with USB cable | Managed automatically by the device on cable attach/detach — do not fight it |
+| 9 | *Flag, not a rail*: status-LED enable | set | When set, the device's status LED shows heartbeat/activity and the application CPUs mirror it. Clear for LED-quiet operation. Safe either way; no rail moves |
+| 10 | Addressable RGB LEDs | no | — |
+| 11 | Analog subsystem (DAC, ADC, op-amps) | no | — |
+| 12 | Auxiliary display-side rail | no | Function not firmly established — leave alone unless confirmed needed |
+| 13 | NFC + low-frequency RFID | no | — |
+| 14 | USB-serial bridge | with USB cable | Managed automatically on cable attach/detach |
+| 15 | CAN controller + transceiver | no | — |
+| 16 | On-board debug probe | with USB cable | Off mid-session = you lose your debugger. Managed automatically on cable attach/detach |
+| 17 | Compute module + its microSD | no | **Not usable through this interface**: its run/enable line is a reserved control bit (held clear). No safe-shutdown path exists — never cut power to a running module |
+
+Notes on the map:
+
+- **The boot-on set is a property of the device firmware and may change
+  between versions. Do not rely on it** — request the zones your
+  application needs explicitly, every time.
+- **Omitting a zone from the awake mask switches it off.** The pattern
+  that prevents blanking your own display on the first attempt: read
+  live rail state, OR in the zones you need, send the complete mask
+  (`picpwr_keep_awake()` / `picpwr_ensure_awake()` do this for you).
+- The display CPU's own rail is not in the mask at all; it cannot be
+  reached — and therefore cannot be switched off by accident.
+- Nothing in 1–17 is electrically unsafe to switch off. The real risks
+  are data loss (zones 7 and 17) and losing the interface you are
+  working through (zones 2, 8, 16).
+- Whether a zone's peripheral is usable from a display-CPU application
+  is a bus-topology question this document does not settle. The
+  checkable rule: if this BSP ships a driver for the peripheral, the
+  zone is usable from here; if it does not, treat it as not supported
+  yet rather than as a hardware limitation.
+
+## Reading rail state back
+
+Rail state is confirmed from the **unsolicited status frame** (the same
+one carrying buttons/charger data), not from any cache. In its 20-byte
+payload, high = powered:
+
+| Zone | Byte | Mask | | Zone | Byte | Mask |
+|---|---|---|---|---|---|---|
+| 1 | 3 | 0x08 | | 10 | 5 | 0x08 |
+| 2 | 3 | 0x10 | | 11 | 5 | 0x10 |
+| 3 | 3 | 0x20 | | 12 | 5 | 0x20 |
+| 4 | 3 | 0x40 | | 13 | 6 | 0x01 |
+| 5 | 3 | 0x80 | | 14 | 6 | 0x02 |
+| 6 | 4 | 0x01 | | 15 | 6 | 0x04 |
+| 7 | 4 | 0x02 | | 16 | 6 | 0x10 |
+| 8 | 5 | 0x02 | | 17 | 7 | 0x08 |
+| 9 | 5 | 0x04 | | | | |
+
+Byte indices are into the 20-byte payload (frame bytes 2–21). The status
+frame also carries indications for the reserved control lines (byte 6
+`0x08`, byte 7 `0x01`, byte 5 `0x80`). **Exclude them — and everything
+above zone 17 — from any requested-vs-actual comparison**: one of those
+pins is set high by the coprocessor's own boot code but never written by
+the rail walk, so a command correctly sending 0 reads back 1 forever. A
+comparison that includes it mismatches permanently and, if wired to a
+debounced re-assert, thrashes the link with rail walks. Compare zones
+1–17 only.
+
+## Timing and serialization
+
+Applying a mask runs a **staggered rail walk with roughly one second of
+inrush delay per pass, during which the coprocessor does not parse the
+link**. Rules:
+
+- Never send frames back-to-back; allow well over one second between
+  commands (`picpwr_send()` enforces 1.5 s) and never stack retries.
+- A mask is applied unconditionally even when nothing changed — every
+  send costs a walk.
+- Do not judge success until the walk completes; then confirm via the
+  status frame.
+
+## Autonomous rail changes
+
+The coprocessor changes rails on its own; caches go stale:
+
+- USB detach/attach clears/restores the USB-bridge and debug-probe rails.
+- Sleep applies the sleep mask; wake re-applies the coprocessor's cached
+  awake mask.
+- Low-battery, long-button-hold and ship-mode shutdowns drop everything;
+  a coprocessor watchdog reset returns to the boot subset.
+
+There is no keepalive and no idle timeout. Applications that depend on a
+rail should watch the status frame and re-assert (debounced — never
+during a walk) if their rail reads off. `picpwr_keep_awake()` +
+`picpwr_task()` implement exactly this.
+
+## Usage guidance
+
+- Request rails **before** initializing the peripherals that sit on
+  them: a rail transition can disturb devices already operating on a
+  shared bus, and a peripheral initialized before its rail is stable
+  reads back garbage.
+- After a rail walk completes, re-initialize shared-bus state (e.g. run
+  I2C bus recovery) before first use if devices on that bus were live
+  during the walk.
+- Status frames may be absent for several seconds after the display CPU
+  resets; tolerate that rather than treating it as a dead link.
+- Never seed an awake mask from a single status frame: use two agreeing
+  frames (as `picpwr_ensure_awake()` does) or send a superset. A stale
+  snapshot echoed back switches off every rail it failed to report.
+
+## Out-of-band bytes
+
+Bare, unframed single bytes appear between and even inside frames; the
+parser tolerates them anywhere:
+
+| Byte | Meaning |
+|---|---|
+| `0xC9` | RX active (handshake gate) |
+| `0xE5` | frame parsed, checksum OK |
+| `0xE4` | checksum mismatch |
+| `0xE2` | unrecognized command id |
+| `0xE1` | first byte was not the command sync |
+
+`0xE5` acknowledges the parse only — rails have not necessarily finished
+moving. There is no dedicated reply to the power-zone command; confirm
+via the status frame.

--- a/docs/drivers/power.md
+++ b/docs/drivers/power.md
@@ -106,7 +106,7 @@ zone 1 is bit 0 of the **last** byte and zone 17 is bit 0 of the first.
 | 9 | *Flag, not a rail*: status-LED enable | set | When set, the device's status LED shows heartbeat/activity and the application CPUs mirror it. Clear for LED-quiet operation. Safe either way; no rail moves |
 | 10 | Addressable RGB LEDs | no | — |
 | 11 | Analog subsystem (DAC, ADC, op-amps) | no | — |
-| 12 | Auxiliary display-side rail | no | Function not firmly established — leave alone unless confirmed needed |
+| 12 | No confirmed load | no | Leave in its default state. Not required for the LCD (verified: apps draw with it off); video-output involvement unverified |
 | 13 | NFC + low-frequency RFID | no | — |
 | 14 | USB-serial bridge | with USB cable | Managed automatically on cable attach/detach |
 | 15 | CAN controller + transceiver | no | — |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -271,6 +271,14 @@ target_include_directories(test_agentio_shadow PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME agentio_shadow COMMAND test_agentio_shadow)
 
+add_executable(test_picpwr_frame
+    test_picpwr_frame.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bsp/input/picpwr_frame.c)
+target_include_directories(test_picpwr_frame PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bsp
+    ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME picpwr_frame COMMAND test_picpwr_frame)
+
 add_executable(test_rc_compose
     test_rc_compose.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../apps/retrochat/compose.c

--- a/tests/test_picpwr_frame.c
+++ b/tests/test_picpwr_frame.c
@@ -1,0 +1,92 @@
+#include <string.h>
+#include "input/picpwr_frame.h"
+#include "test_util.h"
+
+/* Frame construction against the documented worked example:
+ * zones 1-17 awake, sleep and wake fields zero. */
+static void test_frame_worked_example(void)
+{
+    const uint8_t expect[PICPWR_FRAME_LEN] = {
+        0xB0, 0x00, 0x01, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAF,
+    };
+    picpwr_cfg_t cfg = { .awake = 0x01FFFFu, .sleep = 0, .wake = 0,
+                         .wake2 = 0 };
+    uint8_t out[PICPWR_FRAME_LEN];
+    ASSERT_EQ(picpwr_frame_build(out, &cfg), PICPWR_FRAME_LEN);
+    ASSERT_TRUE(memcmp(out, expect, sizeof expect) == 0);
+}
+
+/* Masks serialize most-significant byte first, independently per field. */
+static void test_frame_mask_placement(void)
+{
+    picpwr_cfg_t cfg = { .awake = 0x013456u, .sleep = 0x01CDEFu,
+                         .wake = 0x5A, .wake2 = 0xA5 };
+    uint8_t out[PICPWR_FRAME_LEN];
+    picpwr_frame_build(out, &cfg);
+    ASSERT_EQ(out[2], 0x01); ASSERT_EQ(out[3], 0x34); ASSERT_EQ(out[4], 0x56);
+    ASSERT_EQ(out[5], 0x01); ASSERT_EQ(out[6], 0xCD); ASSERT_EQ(out[7], 0xEF);
+    ASSERT_EQ(out[8], 0x5A); ASSERT_EQ(out[9], 0xA5);
+    uint8_t sum = 0;
+    for (int i = 0; i < PICPWR_FRAME_LEN - 1; i++)
+        sum = (uint8_t)(sum + out[i]);
+    ASSERT_EQ(out[PICPWR_FRAME_LEN - 1], sum);
+}
+
+/* Reserved mask bits (above zone 17) can never reach the wire: the
+ * builder strips them from both masks regardless of the caller's cfg
+ * (docs/drivers/power.md). This test pins that guarantee. */
+static void test_frame_reserved_bits_stripped(void)
+{
+    picpwr_cfg_t cfg = { .awake = 0xFFFFFFu, .sleep = 0xFE0000u,
+                         .wake = 0, .wake2 = 0 };
+    uint8_t out[PICPWR_FRAME_LEN];
+    picpwr_frame_build(out, &cfg);
+    ASSERT_EQ(out[2], 0x01);   /* awake byte 0: only zone 17 survives */
+    ASSERT_EQ(out[3], 0xFF);
+    ASSERT_EQ(out[4], 0xFF);
+    ASSERT_EQ(out[5], 0x00);   /* sleep byte 0: reserved-only mask -> 0 */
+    ASSERT_EQ(out[6], 0x00);
+    ASSERT_EQ(out[7], 0x00);
+    ASSERT_EQ(PICPWR_ZONE_MASK_ALL, 0x01FFFFu);
+}
+
+/* Zone bit helper: zone N = bit N-1. */
+static void test_zone_bits(void)
+{
+    ASSERT_EQ(picpwr_zone_bit(PICPWR_ZONE_SENSORS), 0x000001u);
+    ASSERT_EQ(picpwr_zone_bit(PICPWR_ZONE_DISPLAY), 0x000002u);
+    ASSERT_EQ(picpwr_zone_bit(PICPWR_ZONE_AUDIO), 0x000004u);
+    ASSERT_EQ(picpwr_zone_bit(PICPWR_ZONE_STATUS_LED), 0x000100u);
+    ASSERT_EQ(picpwr_zone_bit(PICPWR_ZONE_CAN), 0x004000u);
+    ASSERT_EQ(picpwr_zone_bit(PICPWR_ZONE_DEBUG_PROBE), 0x008000u);
+    ASSERT_EQ(picpwr_zone_bit(PICPWR_ZONE_COMPUTE), 0x010000u);
+}
+
+/* Rail-state extraction from a synthetic status payload. */
+static void test_rails_decode(void)
+{
+    uint8_t p[20];
+    memset(p, 0, sizeof p);
+    ASSERT_EQ(picpwr_rails_decode(p), 0);
+
+    p[3] = 0x28;                 /* zones 1 (0x08) + 3 (0x20) */
+    p[6] = 0x04;                 /* zone 15 */
+    ASSERT_EQ(picpwr_rails_decode(p),
+              picpwr_zone_bit(1) | picpwr_zone_bit(3)
+                  | picpwr_zone_bit(15));
+
+    /* All payload bits set: exactly zones 1-17, nothing above leaks in. */
+    memset(p, 0xFF, sizeof p);
+    ASSERT_EQ(picpwr_rails_decode(p), 0x01FFFFu);
+}
+
+int main(void)
+{
+    test_frame_worked_example();
+    test_frame_mask_placement();
+    test_frame_reserved_bits_stripped();
+    test_zone_bits();
+    test_rails_decode();
+    if (g_failures == 0) printf("test_picpwr_frame: all passed\n");
+    TEST_RETURN();
+}


### PR DESCRIPTION
cc @evaderkrub @theRealMartBogart

The power sequencer enables only a subset of rails at boot; peripherals
outside it (notably the audio codec and CAN transceiver) stay unpowered.
The BSP could parse the sequencer's status frames but had no transmit
path, so an application had no way to request the rails its peripherals
need. This adds the missing half.

## What's here

- **`uartkbd`**: command TX on the existing link — break/activity-byte
  handshake with fallback timeout, the activity byte intercepted ahead
  of the frame parser (any partial frame dropped and resynced), and raw
  status-payload access.
- **`picpwr`**: the power-zone command. Pure frame build/decode
  (host-testable) plus an application API:
  - `picpwr_keep_awake(zones)` — the one call most apps need: bring
    these rails up and keep them up.
  - `picpwr_task()` — poll from the main loop; re-asserts kept rails if
    they read as off (debounced over two status frames, rate-limited
    past the device's apply time).
  - `picpwr_ensure_awake(zones)` / `picpwr_send(cfg)` /
    `picpwr_rails(&state)` — additive one-shot, full four-field control,
    and live rail state, for apps that need more.
- **`docs/drivers/power.md`**: the protocol — frame format, handshake,
  mask encoding, rail-state decode table, timing rules, usage guidance.
- **Host tests**: worked-example frame + checksum, mask placement,
  reserved-bit stripping, rail-state decode. `ctest`-runnable, no
  hardware.

## Safety properties

- Awake masks are never seeded from a single status frame: live state is
  trusted only when two distinct frames agree, and the keep-awake path
  is strictly additive — it can never switch off a rail that is on.
- Mask bits above zone 17 are **reserved, must-be-zero**: stripped at
  serialization with no caller path to set them (pinned by a host test)
  and excluded from all requested-vs-actual comparisons.
- One send per apply window: commands are rate-limited past the
  device's rail-walk time, so retries can never stack.

## Typical use

```c
uartkbd_init();
picpwr_keep_awake(picpwr_zone_bit(PICPWR_ZONE_AUDIO));
// ... init the codec once the rail reads up ...
while (true) {
    uartkbd_task();
    picpwr_task();
    // app loop
}
```

Request rails **before** initializing the peripherals on them, and
re-run I2C bus recovery after a rail walk if devices on a shared bus
were live during it (see the usage-guidance section of the doc).

## Zone map

`docs/drivers/power.md` includes the full zone-to-peripheral table
(boot-on set, per-zone cautions, the zone-9 status-LED flag, and which
zones are not usable through this interface), and `picpwr_frame.h` names
all 17 zones. The boot-on set is firmware-defined and documented as
not-to-be-relied-on: apps request what they need explicitly.

## Existing examples

Against sequencer firmware that boots these rails off, `hello_audio`,
`retrochat`, and `hello_cc1101` need the pattern from "Typical use"
above added before their peripheral init — `picpwr_keep_awake()` with
the audio zone for the first two and the sub-GHz zone for the third,
plus `picpwr_task()` in their loops. Left out of this PR so each app
change can be tested on its own hardware; happy to follow up. A new AGENTS.md section points agents and
contributors at the pattern so new apps get it right from the start.

## Tested

On hardware (display CPU, stock coprocessor firmware): cold boot with
rails down → audio and CAN rails commanded up and confirmed via the
status frame; codec initializes and passes audio end to end; warm boot
skips the send. Host tests pass with no hardware attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


