### PR TITLE
fix(picpwr): re-assert a superset, never a mask rebuilt from a snapshot

### DIFF
--- a/bsp/input/picpwr.c
+++ b/bsp/input/picpwr.c
@@ -117,6 +117,6 @@ void picpwr_task(void)
         return;
     }
     picpwr_cfg_t cfg = s_cache;
-    cfg.awake = rails | s_desired;
+    cfg.awake = picpwr_reassert_awake(s_cache.awake, rails, s_desired);
     if (picpwr_send(&cfg)) missing = false;
 }

--- a/bsp/input/picpwr_frame.h
+++ b/bsp/input/picpwr_frame.h
@@ -63,4 +63,23 @@ size_t picpwr_frame_build(uint8_t out[PICPWR_FRAME_LEN],
  * High = rail powered. */
 uint32_t picpwr_rails_decode(const uint8_t payload[20]);
 
+/* Awake mask for re-asserting rails after a kept rail reads off.
+ *
+ * A re-assert MUST be a superset of what was already requested, never a
+ * mask rebuilt from a status snapshot: any zone bit left clear in awake
+ * switches that rail OFF, so echoing a snapshot back switches off every
+ * rail it failed to report (docs/drivers/power.md, "Usage guidance").
+ * ORing the last-sent mask in makes a re-assert incapable of clearing
+ * anything that was previously asked for.
+ *
+ *   cached_awake — awake mask of the last cfg actually sent
+ *   rails        — live rail state from the status frame
+ *   desired      — accumulated picpwr_keep_awake() requests
+ */
+static inline uint32_t picpwr_reassert_awake(uint32_t cached_awake,
+                                            uint32_t rails,
+                                            uint32_t desired) {
+    return (cached_awake | rails | desired) & PICPWR_ZONE_MASK_ALL;
+}
+
 #endif /* PICPWR_FRAME_H */

--- a/tests/test_picpwr_frame.c
+++ b/tests/test_picpwr_frame.c
@@ -80,6 +80,44 @@ static void test_rails_decode(void)
     ASSERT_EQ(picpwr_rails_decode(p), 0x01FFFFu);
 }
 
+/* A re-assert is a SUPERSET of what was already requested. Because any
+ * zone bit left clear in awake switches that rail OFF, a mask rebuilt
+ * from a status snapshot switches off every rail the snapshot failed to
+ * report (docs/drivers/power.md). These cases pin that it cannot. */
+static void test_reassert_is_superset(void)
+{
+    const uint32_t audio = picpwr_zone_bit(PICPWR_ZONE_AUDIO);
+    const uint32_t probe = picpwr_zone_bit(PICPWR_ZONE_DEBUG_PROBE);
+    const uint32_t disp  = picpwr_zone_bit(PICPWR_ZONE_DISPLAY);
+
+    /* The regression: a zone that was sent, but that a stale snapshot
+     * reports off and that is not in `desired`, must still survive.
+     * Rebuilding from (rails | desired) alone would drop it. */
+    ASSERT_EQ(picpwr_reassert_awake(disp | probe, audio, audio),
+              disp | probe | audio);
+
+    /* Every input is retained; nothing a caller asked for is cleared. */
+    ASSERT_EQ(picpwr_reassert_awake(disp, probe, audio),
+              disp | probe | audio);
+
+    /* An all-zero snapshot cannot clear the cached request. */
+    ASSERT_EQ(picpwr_reassert_awake(disp | audio, 0, 0), disp | audio);
+
+    /* Monotonic: the result is always a superset of each input. */
+    uint32_t r = picpwr_reassert_awake(disp, probe, audio);
+    ASSERT_EQ(r & disp, disp);
+    ASSERT_EQ(r & probe, probe);
+    ASSERT_EQ(r & audio, audio);
+
+    /* Reserved bits above zone 17 never survive, whichever input
+     * carried them. */
+    ASSERT_EQ(picpwr_reassert_awake(0xFE0000u, 0, audio), audio);
+    ASSERT_EQ(picpwr_reassert_awake(0, 0xFE0000u, audio), audio);
+    ASSERT_EQ(picpwr_reassert_awake(0, 0, 0xFE0000u | audio), audio);
+    ASSERT_EQ(picpwr_reassert_awake(0xFFFFFFu, 0xFFFFFFu, 0xFFFFFFu),
+              PICPWR_ZONE_MASK_ALL);
+}
+
 int main(void)
 {
     test_frame_worked_example();
@@ -87,6 +125,7 @@ int main(void)
     test_frame_reserved_bits_stripped();
     test_zone_bits();
     test_rails_decode();
+    test_reassert_is_superset();
     if (g_failures == 0) printf("test_picpwr_frame: all passed\n");
     TEST_RETURN();
 }


### PR DESCRIPTION
## The bug

`picpwr_task()` re-asserts rails when a kept rail reads off, but builds the
awake mask from the live status snapshot:

```c
picpwr_cfg_t cfg = s_cache;
cfg.awake = rails | s_desired;   /* discards s_cache.awake */
```

Any zone bit left clear in `awake` switches that rail **off**. So every zone
that was previously sent, but that the snapshot reports off and that is not in
`s_desired`, gets switched off by the rail walk the re-assert triggers — the
opposite of what a re-assert is for.

## It contradicts the driver's own documented rule

`docs/drivers/power.md`, "Usage guidance", already describes this failure:

> Never seed an awake mask from a single status frame: use two agreeing frames
> (as `picpwr_ensure_awake()` does) or send a superset. A stale snapshot echoed
> back switches off every rail it failed to report.

The existing debounce satisfies the "two agreeing frames" half. The mask it
then builds is not a superset, so the guarantee was still lost.

## Bench evidence

On the bench 2026-07-30 the on-board CMSIS-DAP probe
(`PICPWR_ZONE_DEBUG_PROBE`) dropped off USB within seconds of any run that
injected **button** events, while touch-only runs were stable for hours. Button
injection shares the `uartkbd` frame stream that carries rail telemetry, so
those runs are the ones that evaluate a status frame.

On the observed case the old expression clears the probe's own bit:

| cached (sent) | rails (snapshot) | desired | old `awake` | new `awake` |
|---|---|---|---|---|
| `0x008002` DISPLAY+PROBE | `0x000004` AUDIO | `0x000004` | **`0x000004`** | `0x008006` |

After the fix, a full 14-check button suite runs start to finish with the probe
still enumerated.

## The change

One term, but moved somewhere testable. The mask arithmetic is now
`picpwr_reassert_awake()` in `picpwr_frame.h`, alongside the rest of the pure
frame/mask logic:

```c
cfg.awake = picpwr_reassert_awake(s_cache.awake, rails, s_desired);
```

`tests/test_picpwr_frame.c` pins the invariant — the regression case, that no
input can be cleared, and that reserved bits above zone 17 cannot enter from
any of the three arguments. No build-system changes: the header is inline and
that test target already exists.

If you would rather keep the driver untouched structurally, the equivalent
one-liner in `picpwr.c` is `cfg.awake = s_cache.awake | rails | s_desired;` —
happy to reduce it to that.

## Verification, honestly

- Assertions compile clean under `-Wall -Wextra -Werror`, and their expected
  values were computed independently and match.
- **`fw test` was not run here** — this host has no native C toolchain, only
  `arm-none-eabi`. The new cases need CI or a host with MinGW to be confirmed
  green. Nothing else in the suite was touched.
- The behavioral claim above is from hardware, not from reasoning about the
  code.
