### PR TITLE
feat(ft6336): add two-point poll (ft6336_poll2)

### DIFF
--- a/bsp/input/ft6336.c
+++ b/bsp/input/ft6336.c
@@ -46,6 +46,32 @@ void ft6336_inject_set(uint16_t x, uint16_t y, bool down) {
 
 uint32_t ft6336_inject_reads(void) { return s_inj_reads; }
 
+int ft6336_poll2(uint16_t* x1, uint16_t* y1, uint16_t* x2, uint16_t* y2) {
+    if (s_inj_down) {            // injected point wins; no I2C traffic at all
+        *x1 = s_inj_x;
+        *y1 = s_inj_y;
+        s_inj_reads++;
+        return 1;
+    }
+    // One transaction over regs 0x02..0x0C: TD_STATUS + both point latches
+    // coherent (P1 at 0x03, weight/misc at 0x07/0x08, P2 at 0x09).
+    uint8_t b[11];
+    if (!ft_rd(FT6336_REG_TD_STATUS, b, 11)) return 0;
+    int n = b[0] & 0x0F;
+    if (n < 1 || n > 2) return 0;
+    ft_point_t p = ft6336_map_point((((int)(b[1] & 0x0F)) << 8) | b[2],
+                                    (((int)(b[3] & 0x0F)) << 8) | b[4]);
+    *x1 = p.x;
+    *y1 = p.y;
+    if (n == 2) {
+        p = ft6336_map_point((((int)(b[7] & 0x0F)) << 8) | b[8],
+                             (((int)(b[9] & 0x0F)) << 8) | b[10]);
+        *x2 = p.x;
+        *y2 = p.y;
+    }
+    return n;
+}
+
 bool ft6336_poll(uint16_t* x, uint16_t* y) {
     if (s_inj_down) {            // injected point wins; no I2C traffic at all
         *x = s_inj_x;

--- a/bsp/input/ft6336.h
+++ b/bsp/input/ft6336.h
@@ -16,6 +16,14 @@ bool ft6336_init(void);
 // and returns true; returns false when nothing (or more than one point) is touched.
 bool ft6336_poll(uint16_t* x, uint16_t* y);
 
+// Poll for up to TWO touch points (the FT6336U's hardware maximum). Returns
+// the point count 0..2 and fills (x1,y1) — and (x2,y2) when two are down —
+// oriented to the panel like ft6336_poll. NOTE: register slot order follows
+// the chip's touch IDs, so after one of two fingers lifts, the survivor may
+// appear in either slot — callers should track points as a SET, not by slot.
+// An injected point reports as a single touch.
+int ft6336_poll2(uint16_t* x1, uint16_t* y1, uint16_t* x2, uint16_t* y2);
+
 // agentio touch injection. While `down` is set, ft6336_poll() returns the
 // injected point and skips the I2C read entirely, so injection works with no
 // finger (and no touch controller) present. ft6336_inject_reads() counts polls


### PR DESCRIPTION
## Why

`ft6336_poll()` returns a single point and reports **false** when more than one
finger is down, so the FT6336U's second touch point is unreachable through the
BSP today. Any app wanting pinch, two-finger gestures, or just graceful
behaviour when a user rests a second thumb on the panel has to bypass the
driver.

This adds `ft6336_poll2()` alongside it. `ft6336_poll()` is untouched, so
nothing that exists today changes behaviour.

```c
int ft6336_poll2(uint16_t *x1, uint16_t *y1, uint16_t *x2, uint16_t *y2);
```

Returns the point count (0..2), oriented to the panel exactly like
`ft6336_poll()`, and fills `(x2,y2)` only when two points are down.

## Implementation notes

- **One I2C transaction** covering regs `0x02..0x0C`, so `TD_STATUS` and both
  point latches are read coherently. Reading the second point separately would
  let a finger lift between transactions and mix state from two different
  scans.
- Injected touches (`ft6336_inject_set()`) report as a single point and skip
  I2C entirely, matching `ft6336_poll()` — so agentio-driven tests keep working
  against either entry point.

## One caveat, documented in the header

Register slot order follows the chip's touch IDs, not a stable "first finger /
second finger" order. After one of two fingers lifts, the survivor can appear
in **either** slot. Callers should track points as a set rather than assuming
slot 1 is the same finger frame to frame. That is chip behaviour, not something
this wrapper can hide, so it is called out in the header comment where someone
will actually read it.

## Verification

Used continuously in an audio app built on this BSP — a two-finger keyboard
where both points drive independent voices, on real hardware. Compile-checked
clean with `-Wall -Wextra` for cortex-m33.

`fw test` has no coverage here and this PR adds none: the function is a
register-layout wrapper around an I2C read, so a host test would only assert
against a mock of the chip. The pure part it depends on
(`ft6336_map_point()`) is already exercised.
