### PR TITLE
fix(i2c): bound every I2C transfer, and recover a wedged bus at init

### DIFF
--- a/bsp/audio/codec_nau88c10.c
+++ b/bsp/audio/codec_nau88c10.c
@@ -11,11 +11,20 @@
 
 #define CODEC_ADDR 26   // 0x1A, from the vendor driver
 
+/* Every codec transfer is time-bounded: the codec shares I2C1 with the
+ * touch controller and sensors, and a device that loses its supply
+ * mid-transfer can hold the bus, which would otherwise park an untimed
+ * transfer forever. 2 ms is well over a 2-byte transfer at 400 kHz.
+ * Failed transfers are reported and skipped; init continues so a caller
+ * can report an absent codec rather than hang. */
+#define CODEC_I2C_TIMEOUT_US 2000
+
 static void codec_write(uint8_t reg, uint16_t val) {
     // NAU88C10 register write: 7-bit register + 9-bit value packed as
     // byte0 = reg<<1 | val[8], byte1 = val[7:0] (vendor CODEC_IO_Write).
     uint8_t msg[2] = { (uint8_t)((reg << 1) | ((val >> 8) & 1)), (uint8_t)(val & 0xFF) };
-    int rc = i2c_write_blocking(i2c1, CODEC_ADDR, msg, 2, false);
+    int rc = i2c_write_timeout_us(i2c1, CODEC_ADDR, msg, 2, false,
+                                 CODEC_I2C_TIMEOUT_US);
     if (rc != 2) DIAG("codec: i2c write reg 0x%02x failed (%d)\n", reg, rc);
 }
 
@@ -149,9 +158,11 @@ void codec_nau88c10_dump(void) {
     for (uint8_t reg = 0; reg <= 0x45; reg++) {
         uint8_t addr_byte = (uint8_t)(reg << 1);
         uint8_t val[2] = { 0, 0 };
-        int rc = i2c_write_blocking(i2c1, CODEC_ADDR, &addr_byte, 1, true);
+        int rc = i2c_write_timeout_us(i2c1, CODEC_ADDR, &addr_byte, 1, true,
+                                      CODEC_I2C_TIMEOUT_US);
         if (rc != 1) { DIAG("codec: dump write reg 0x%02x failed (%d)\n", reg, rc); return; }
-        rc = i2c_read_blocking(i2c1, CODEC_ADDR, val, 2, false);
+        rc = i2c_read_timeout_us(i2c1, CODEC_ADDR, val, 2, false,
+                                 CODEC_I2C_TIMEOUT_US);
         if (rc != 2) { DIAG("codec: dump read 0x%02x failed (%d)\n", reg, rc); return; }
         DIAG("codec: reg 0x%02x = 0x%03x\n", reg, (unsigned)(((val[0] & 0x01) << 8) | val[1]));
     }
@@ -164,8 +175,10 @@ void codec_nau88c10_dac_mute(bool mute) {
 static uint16_t codec_read(uint8_t reg) {
     uint8_t addr_byte = (uint8_t)(reg << 1);
     uint8_t val[2] = { 0, 0 };
-    if (i2c_write_blocking(i2c1, CODEC_ADDR, &addr_byte, 1, true) != 1) return 0xFFFF;
-    if (i2c_read_blocking(i2c1, CODEC_ADDR, val, 2, false) != 2) return 0xFFFF;
+    if (i2c_write_timeout_us(i2c1, CODEC_ADDR, &addr_byte, 1, true,
+                             CODEC_I2C_TIMEOUT_US) != 1) return 0xFFFF;
+    if (i2c_read_timeout_us(i2c1, CODEC_ADDR, val, 2, false,
+                            CODEC_I2C_TIMEOUT_US) != 2) return 0xFFFF;
     return (uint16_t)(((val[0] & 0x01) << 8) | val[1]);
 }
 

--- a/bsp/input/ft6336.c
+++ b/bsp/input/ft6336.c
@@ -7,6 +7,10 @@
 #include "hardware/i2c.h"
 #include "platform/diag.h"
 
+/* Bounded transfers: this bus is shared, and a device that loses its
+ * supply or is reset mid-transfer can hold it. */
+#define I2C_XFER_TIMEOUT_US 2000
+
 #define FT6336_I2C             i2c1
 #define FT6336_ADDR            0x38
 #define FT6336_REG_DEVICE_MODE 0x00   // 0 = normal operating mode
@@ -19,16 +23,15 @@
 // first real two-finger session — cores alive, UI parked in i2c waits).
 // 2 ms is ~10x a normal 11-byte transaction at 400 kHz.
 static bool ft_rd(uint8_t reg, uint8_t* buf, uint8_t n) {
-    if (i2c_write_timeout_us(FT6336_I2C, FT6336_ADDR, &reg, 1, true,
-                             2000) != 1) return false;
-    return i2c_read_timeout_us(FT6336_I2C, FT6336_ADDR, buf, n, false,
-                               2000) == (int)n;
+
+    if (i2c_write_timeout_us(FT6336_I2C, FT6336_ADDR, &reg, 1, true, I2C_XFER_TIMEOUT_US) != 1) return false;
+    return i2c_read_timeout_us(FT6336_I2C, FT6336_ADDR, buf, n, false, I2C_XFER_TIMEOUT_US) == (int)n;
 }
 
 // Write one register = val.
 static bool ft_wr(uint8_t reg, uint8_t val) {
     uint8_t b[2] = { reg, val };
-    return i2c_write_blocking(FT6336_I2C, FT6336_ADDR, b, 2, false) == 2;
+    return i2c_write_timeout_us(FT6336_I2C, FT6336_ADDR, b, 2, false, I2C_XFER_TIMEOUT_US) == 2;
 }
 
 bool ft6336_init(void) {

--- a/bsp/input/ft6336.c
+++ b/bsp/input/ft6336.c
@@ -13,10 +13,16 @@
 #define FT6336_REG_TD_STATUS   0x02   // low nibble = number of touch points
 #define FT6336_REG_CHIP_ID     0xA3   // chip-id register (presence check)
 
-// Write the register pointer (no stop), then read n bytes.
+// Write the register pointer (no stop), then read n bytes. TIMEOUT reads:
+// this poll runs every UI-loop pass, and an untimed blocking read turned a
+// wedged I2C bus into a permanently hung UI (bench incident 2026-07-29,
+// first real two-finger session — cores alive, UI parked in i2c waits).
+// 2 ms is ~10x a normal 11-byte transaction at 400 kHz.
 static bool ft_rd(uint8_t reg, uint8_t* buf, uint8_t n) {
-    if (i2c_write_blocking(FT6336_I2C, FT6336_ADDR, &reg, 1, true) != 1) return false;
-    return i2c_read_blocking(FT6336_I2C, FT6336_ADDR, buf, n, false) == (int)n;
+    if (i2c_write_timeout_us(FT6336_I2C, FT6336_ADDR, &reg, 1, true,
+                             2000) != 1) return false;
+    return i2c_read_timeout_us(FT6336_I2C, FT6336_ADDR, buf, n, false,
+                               2000) == (int)n;
 }
 
 // Write one register = val.

--- a/bsp/platform/board.c
+++ b/bsp/platform/board.c
@@ -70,7 +70,43 @@ void board_backlight_set(uint8_t level) {
     gpio_put(PIN_LCD_BL, level != 0);
 }
 
+/* A device interrupted mid-transfer — a supply that moved under it, or a
+ * reset while it was driving — can hold SDA low and wedge the bus for
+ * every other device on it. Clocking SCL with SDA released lets that
+ * device finish the byte it thinks it is sending, after which a STOP
+ * returns the bus to idle. Runs before the I2C function is assigned. */
+static void i2c1_bus_recover(void) {
+    gpio_init(PIN_I2C1_SDA);
+    gpio_init(PIN_I2C1_SCL);
+    gpio_set_dir(PIN_I2C1_SDA, GPIO_IN);          /* released, pulled up */
+    gpio_pull_up(PIN_I2C1_SDA);
+    gpio_pull_up(PIN_I2C1_SCL);
+    gpio_set_dir(PIN_I2C1_SCL, GPIO_OUT);
+    gpio_put(PIN_I2C1_SCL, 1);
+    sleep_us(10);
+    if (gpio_get(PIN_I2C1_SDA)) {                 /* bus already idle */
+        gpio_set_dir(PIN_I2C1_SCL, GPIO_IN);
+        return;
+    }
+    for (int i = 0; i < 9 && !gpio_get(PIN_I2C1_SDA); i++) {
+        gpio_put(PIN_I2C1_SCL, 0);
+        sleep_us(5);
+        gpio_put(PIN_I2C1_SCL, 1);
+        sleep_us(5);
+    }
+    /* STOP: SDA low->high while SCL is high. */
+    gpio_set_dir(PIN_I2C1_SDA, GPIO_OUT);
+    gpio_put(PIN_I2C1_SDA, 0);
+    sleep_us(5);
+    gpio_put(PIN_I2C1_SCL, 1);
+    sleep_us(5);
+    gpio_set_dir(PIN_I2C1_SDA, GPIO_IN);
+    sleep_us(5);
+    gpio_set_dir(PIN_I2C1_SCL, GPIO_IN);
+}
+
 void board_i2c1_init(void) {
+    i2c1_bus_recover();
     i2c_init(i2c1, 400 * 1000);
     gpio_set_function(PIN_I2C1_SDA, GPIO_FUNC_I2C);
     gpio_set_function(PIN_I2C1_SCL, GPIO_FUNC_I2C);

--- a/bsp/platform/ioexp.c
+++ b/bsp/platform/ioexp.c
@@ -31,6 +31,9 @@
 // Shadow of the Port-0 output byte: SPI1 buffer dirs + USB host port 1 power.
 // Default matches ioexp_init(): HP1 OFF.
 #define P0_HP1_EN 0x01   // P0 bit 0: USB host port 1 power, active-high
+#define IOEXP_I2C_TIMEOUT_US 2000   /* bounded: a device holding the
+                                     * bus must not park boot */
+
 static uint8_t s_p0 = P0_OUT;
 
 // Shadow of the Port-2 output byte. Default matches ioexp_init(): IR power OFF,
@@ -51,7 +54,7 @@ static uint8_t s_vref = VREF_EXT_PIN;
 
 static void write_outputs(uint8_t p0, uint8_t p1) {
     uint8_t out[4] = { REG_OUTPUT0, p0, p1, s_p2 };
-    i2c_write_blocking(IOEXP_I2C, IOEXP_ADDR, out, 4, false);
+    i2c_write_timeout_us(IOEXP_I2C, IOEXP_ADDR, out, 4, false, IOEXP_I2C_TIMEOUT_US);
 }
 
 // Map an ANT_* value to the V1_1/V2_1 output bits within Port 1.
@@ -132,8 +135,8 @@ bool ioexp_init(void) {
     uint8_t cfg[4] = { REG_CONFIG0, 0x00, 0x00, 0x04 };   // all output except MCLR (P2_2)
     // Outputs FIRST, then directions (glitch-free: a pin drives its latched value
     // only when its direction flips to output; keeps SCREEN_NRST from pulsing low).
-    bool ok = i2c_write_blocking(IOEXP_I2C, IOEXP_ADDR, out, 4, false) == 4;
-    ok = (i2c_write_blocking(IOEXP_I2C, IOEXP_ADDR, cfg, 4, false) == 4) && ok;
+    bool ok = i2c_write_timeout_us(IOEXP_I2C, IOEXP_ADDR, out, 4, false, IOEXP_I2C_TIMEOUT_US) == 4;
+    ok = (i2c_write_timeout_us(IOEXP_I2C, IOEXP_ADDR, cfg, 4, false, IOEXP_I2C_TIMEOUT_US) == 4) && ok;
     DIAG("ioexp: init %s (LCD reset released; CC1101 + 433 MHz antenna; GPIO VREF = ext pin)\n",
          ok ? "ok" : "NAK");
     return ok;

--- a/bsp/sensors/bmi323.c
+++ b/bsp/sensors/bmi323.c
@@ -4,6 +4,10 @@
 #include "hardware/i2c.h"
 #include "pico/stdlib.h"
 #include "platform/diag.h"
+
+/* Bounded transfers: this bus is shared, and a device that loses its
+ * supply or is reset mid-transfer can hold it. */
+#define I2C_XFER_TIMEOUT_US 2000
 #define BMI323_I2C   i2c1
 #endif
 
@@ -27,14 +31,14 @@ float bmi323_gyro_dps(int16_t raw, int range_dps) { return (float)raw / 32768.0f
 // Write a 16-bit value (little-endian) to a register.
 static bool reg_write16(uint8_t reg, uint16_t val) {
     uint8_t b[3] = { reg, (uint8_t)(val & 0xFF), (uint8_t)(val >> 8) };
-    return i2c_write_blocking(BMI323_I2C, BMI323_ADDR, b, 3, false) == 3;
+    return i2c_write_timeout_us(BMI323_I2C, BMI323_ADDR, b, 3, false, I2C_XFER_TIMEOUT_US) == 3;
 }
 // Read `n16` 16-bit regs from `reg` into out[] (skips BMI323_DUMMY leading bytes).
 static bool reg_read16(uint8_t reg, int16_t *out, int n16) {
     uint8_t buf[BMI323_DUMMY + 16];
     int total = BMI323_DUMMY + 2 * n16;
-    if (i2c_write_blocking(BMI323_I2C, BMI323_ADDR, &reg, 1, true) != 1) return false;
-    if (i2c_read_blocking(BMI323_I2C, BMI323_ADDR, buf, total, false) != total) return false;
+    if (i2c_write_timeout_us(BMI323_I2C, BMI323_ADDR, &reg, 1, true, I2C_XFER_TIMEOUT_US) != 1) return false;
+    if (i2c_read_timeout_us(BMI323_I2C, BMI323_ADDR, buf, total, false, I2C_XFER_TIMEOUT_US) != total) return false;
     for (int i = 0; i < n16; i++) {
         int o = BMI323_DUMMY + 2 * i;
         out[i] = (int16_t)((uint16_t)buf[o] | ((uint16_t)buf[o + 1] << 8));

--- a/bsp/sensors/bmm350.c
+++ b/bsp/sensors/bmm350.c
@@ -7,6 +7,10 @@
 #include "hardware/i2c.h"
 #include "pico/stdlib.h"
 #include "platform/diag.h"
+
+/* Bounded transfers: this bus is shared, and a device that loses its
+ * supply or is reset mid-transfer can hold it. */
+#define I2C_XFER_TIMEOUT_US 2000
 #define BMM350_I2C   i2c1
 #endif
 
@@ -26,13 +30,13 @@ static bmm350_coeff_t s_coeff;
 
 static bool reg_write(uint8_t reg, uint8_t val) {
     uint8_t b[2] = { reg, val };
-    return i2c_write_blocking(BMM350_I2C, BMM350_ADDR, b, 2, false) == 2;
+    return i2c_write_timeout_us(BMM350_I2C, BMM350_ADDR, b, 2, false, I2C_XFER_TIMEOUT_US) == 2;
 }
 #define BMM350_DUMMY 2   // BMM350 I2C reads return 2 leading dummy bytes (confirmed on HW)
 static bool reg_read(uint8_t reg, uint8_t *out, int n) {
     uint8_t buf[BMM350_DUMMY + 16];
-    if (i2c_write_blocking(BMM350_I2C, BMM350_ADDR, &reg, 1, true) != 1) return false;
-    if (i2c_read_blocking(BMM350_I2C, BMM350_ADDR, buf, n + BMM350_DUMMY, false) != n + BMM350_DUMMY)
+    if (i2c_write_timeout_us(BMM350_I2C, BMM350_ADDR, &reg, 1, true, I2C_XFER_TIMEOUT_US) != 1) return false;
+    if (i2c_read_timeout_us(BMM350_I2C, BMM350_ADDR, buf, n + BMM350_DUMMY, false, I2C_XFER_TIMEOUT_US) != n + BMM350_DUMMY)
         return false;
     for (int i = 0; i < n; i++) out[i] = buf[BMM350_DUMMY + i];
     return true;

--- a/bsp/sensors/opt4001.c
+++ b/bsp/sensors/opt4001.c
@@ -3,6 +3,10 @@
 #ifdef PICO_BUILD
 #include "hardware/i2c.h"
 #include "platform/diag.h"
+
+/* Bounded transfers: this bus is shared, and a device that loses its
+ * supply or is reset mid-transfer can hold it. */
+#define I2C_XFER_TIMEOUT_US 2000
 #define OPT4001_I2C  i2c1
 #endif
 
@@ -24,18 +28,18 @@ float opt4001_lux(uint8_t exponent, uint32_t mantissa) {
 bool opt4001_init(void) {
     // CONFIG 0x3238: RANGE=auto(12), CONVERSION_TIME=100ms(8), MODE=continuous(3), LATCH=1.
     uint8_t cfg[3] = { OPT4001_REG_CONFIG, 0x32, 0x38 };
-    bool ok = (i2c_write_blocking(OPT4001_I2C, OPT4001_ADDR, cfg, 3, false) == 3);
+    bool ok = (i2c_write_timeout_us(OPT4001_I2C, OPT4001_ADDR, cfg, 3, false, I2C_XFER_TIMEOUT_US) == 3);
     uint8_t reg = OPT4001_REG_DEVID, id[2] = { 0, 0 };
-    if (i2c_write_blocking(OPT4001_I2C, OPT4001_ADDR, &reg, 1, true) == 1)
-        i2c_read_blocking(OPT4001_I2C, OPT4001_ADDR, id, 2, false);
+    if (i2c_write_timeout_us(OPT4001_I2C, OPT4001_ADDR, &reg, 1, true, I2C_XFER_TIMEOUT_US) == 1)
+        i2c_read_timeout_us(OPT4001_I2C, OPT4001_ADDR, id, 2, false, I2C_XFER_TIMEOUT_US);
     DIAG("opt4001: init %s id=0x%02x%02x\n", ok ? "ok" : "NAK", id[0], id[1]);
     return ok;
 }
 
 bool opt4001_read(float *lux) {
     uint8_t reg = OPT4001_REG_RESULT, b[4];
-    if (i2c_write_blocking(OPT4001_I2C, OPT4001_ADDR, &reg, 1, true) != 1) return false;
-    if (i2c_read_blocking(OPT4001_I2C, OPT4001_ADDR, b, 4, false) != 4) return false;
+    if (i2c_write_timeout_us(OPT4001_I2C, OPT4001_ADDR, &reg, 1, true, I2C_XFER_TIMEOUT_US) != 1) return false;
+    if (i2c_read_timeout_us(OPT4001_I2C, OPT4001_ADDR, b, 4, false, I2C_XFER_TIMEOUT_US) != 4) return false;
     // b[0]: EXPONENT[15:12] | RESULT_MSB[11:8]; b[1]: RESULT_MSB[7:0]; b[2]: RESULT_LSB[7:0]
     uint8_t  exponent   = b[0] >> 4;
     uint32_t result_msb = ((uint32_t)(b[0] & 0x0F) << 8) | b[1];   // 12 bits

--- a/bsp/sensors/sht40.c
+++ b/bsp/sensors/sht40.c
@@ -4,6 +4,10 @@
 #include "hardware/i2c.h"
 #include "pico/stdlib.h"
 #include "platform/diag.h"
+
+/* Bounded transfers: this bus is shared, and a device that loses its
+ * supply or is reset mid-transfer can hold it. */
+#define I2C_XFER_TIMEOUT_US 2000
 #define SHT40_I2C  i2c1
 #endif
 
@@ -36,9 +40,9 @@ bool sht40_convert(const uint8_t raw[6], float *temp_c, float *rh_pct, bool *crc
 #ifdef PICO_BUILD
 bool sht40_init(void) {
     uint8_t cmd = SHT40_CMD_SERIAL, sn[6];
-    bool ok = (i2c_write_blocking(SHT40_I2C, SHT40_ADDR, &cmd, 1, false) == 1);
+    bool ok = (i2c_write_timeout_us(SHT40_I2C, SHT40_ADDR, &cmd, 1, false, I2C_XFER_TIMEOUT_US) == 1);
     sleep_ms(2);
-    ok = ok && (i2c_read_blocking(SHT40_I2C, SHT40_ADDR, sn, 6, false) == 6);
+    ok = ok && (i2c_read_timeout_us(SHT40_I2C, SHT40_ADDR, sn, 6, false, I2C_XFER_TIMEOUT_US) == 6);
     DIAG("sht40: init %s\n", ok ? "ok" : "NAK");
     return ok;
 }
@@ -46,10 +50,10 @@ bool sht40_init(void) {
 bool sht40_read(sht40_reading_t *out) {
     out->valid = false;
     uint8_t cmd = SHT40_CMD_MEASURE;
-    if (i2c_write_blocking(SHT40_I2C, SHT40_ADDR, &cmd, 1, false) != 1) return false;
+    if (i2c_write_timeout_us(SHT40_I2C, SHT40_ADDR, &cmd, 1, false, I2C_XFER_TIMEOUT_US) != 1) return false;
     sleep_ms(10);   // high-precision conversion time
     uint8_t raw[6];
-    if (i2c_read_blocking(SHT40_I2C, SHT40_ADDR, raw, 6, false) != 6) return false;
+    if (i2c_read_timeout_us(SHT40_I2C, SHT40_ADDR, raw, 6, false, I2C_XFER_TIMEOUT_US) != 6) return false;
     bool crc;
     sht40_convert(raw, &out->temp_c, &out->rh_pct, &crc);
     out->valid = crc;


### PR DESCRIPTION
## The problem

Every I2C transfer in `bsp/` used `i2c_read_blocking()` / `i2c_write_blocking()`.
Those have **no timeout**: if a device holds SDA low, the call does not return.
There are 26 such calls on `master`, spread across touch, the codec, the I/O
expander, and all four sensors — and they share one bus (`i2c1`).

So a single wedged device does not degrade one driver. It hangs the caller
forever, and because touch is polled from the UI loop, the practical symptom is
**the whole app freezes with the panel still lit**. Nothing logs, nothing
resets, and it looks like an app bug rather than a bus fault.

This is easy to hit on this board specifically, because peripheral rails come
up and down at runtime. A device that loses its supply mid-transfer, or is reset
while driving SDA, can leave the line held.

## The board's own docs already prescribe the missing half

`docs/drivers/power.md`, "Usage guidance":

> After a rail walk completes, re-initialize shared-bus state (e.g. run I2C bus
> recovery) before first use if devices on that bus were live during the walk.

There was no bus-recovery routine in the BSP to call. This adds one.

## What changed

**1. Bounded transfers.** All 26 calls become `i2c_write_timeout_us()` /
`i2c_read_timeout_us()` with a 2 ms budget — generously above any transaction
these devices need at 400 kHz, low enough that a wedged bus degrades to a
failed read instead of a hang. Return-value checks are unchanged, so every
existing `false`/NAK path still behaves the same; a timeout simply joins the
set of things that make a read fail.

| File | Calls bounded |
|---|---|
| `input/ft6336.c` | touch polling |
| `audio/codec_nau88c10.c` | codec register access |
| `platform/ioexp.c` | PCAL6524 expander |
| `sensors/bmi323.c`, `bmm350.c`, `opt4001.c`, `sht40.c` | all sensor access |

**2. `i2c1_bus_recover()` in `platform/board.c`**, called at the top of
`board_i2c1_init()` before the pins are handed to the I2C peripheral. If SDA
reads low, it clocks SCL up to 9 times so a stuck device can finish the byte it
believes it is transmitting, then issues a STOP to return the bus to idle. If
SDA is already high it does nothing but restore the pins — so the normal boot
path is unaffected.

Nine clocks is the standard remedy (worst case is a device mid-byte plus ACK).
It runs before `gpio_set_function(..., GPIO_FUNC_I2C)` because the pins have to
be plain GPIO to be bit-banged.

## Why bother when a NAK already returns false

Because a NAK and a held line are different failures. A NAK returns; a held
line does not. The existing error handling was correct and complete for the
first case and had no effect at all in the second.

## Verification

- `freewili2_bsp` builds clean for cortex-m33 with this applied.
- Run continuously in an audio app on real hardware (touch polled per UI frame,
  codec and sensors active) with no regression in normal operation — the point
  of the change is the abnormal path.
- **Not** verified by deliberately wedging the bus: that needs holding SDA low
  externally, which I have not rigged. The recovery routine's logic is the
  standard nine-clock remedy but its effect on a genuinely stuck device on this
  board is untested. Worth knowing before merging.
- No host tests: this is all hardware register access. Nothing in `tests/` is
  touched.
