### PR TITLE
fix: make USB hub drive-wait non-blocking

### DIFF
--- a/bsp/usbhost/usb_hub.c
+++ b/bsp/usbhost/usb_hub.c
@@ -27,6 +27,25 @@ static bool         active;
 // attempt below (~100-600 ms) would re-run on every poll forever.
 #define HUB_CONNECT_CONFIRM_POLLS 3
 static uint8_t      connect_streak[8];
+// Bound and back off retries after transient reset/enumeration failures.  A
+// confirmed non-MSC device is blocked immediately; repeated failures are
+// blocked after HUB_ENUM_MAX_ATTEMPTS.  Either condition is cleared by a
+// disconnect/reconnect, so an unsupported or broken device cannot turn the
+// 50 ms poll into a recurring 100-600 ms main-loop stall.
+#define HUB_ENUM_MAX_ATTEMPTS 3
+#define HUB_ENUM_RETRY_BASE_MS 500
+static uint8_t       enum_attempts[8];
+static absolute_time_t enum_retry_at[8];
+static bool          enum_blocked[8];
+
+static void enum_failed(uint8_t port) {
+    if (++enum_attempts[port] >= HUB_ENUM_MAX_ATTEMPTS) {
+        enum_blocked[port] = true;
+        return;
+    }
+    uint32_t delay_ms = HUB_ENUM_RETRY_BASE_MS << (enum_attempts[port] - 1);
+    enum_retry_at[port] = make_timeout_time_ms(delay_ms);
+}
 
 static hcd_result_t hub_set_port_feature(uint8_t port, uint8_t feature) {
     const uint8_t setup[8] = {0x23, 3, feature, 0, port, 0, 0, 0};
@@ -55,6 +74,8 @@ hcd_result_t usb_hub_attach(const usb_device_t *dev) {
     hub = *dev;
     drive_port = -1;
     for (size_t i = 0; i < sizeof connect_streak; i++) connect_streak[i] = 0;
+    for (size_t i = 0; i < sizeof enum_attempts; i++) enum_attempts[i] = 0;
+    for (size_t i = 0; i < sizeof enum_blocked; i++) enum_blocked[i] = false;
 
     // Hub descriptor (class type 0x29): bNbrPorts at offset 2,
     // bPwrOn2PwrGood (2 ms units) at offset 5
@@ -93,8 +114,9 @@ hcd_result_t usb_hub_attach(const usb_device_t *dev) {
 // it at address 2. Non-blocking when nothing is connected (just a handful of
 // quick control transfers, no sleep_ms). When a device IS connected, runs the
 // bounded (~0.6 s worst case) debounce/reset/recovery sequence for that one
-// device before returning -- that cost is unavoidable and only paid once per
-// real attach, not on every idle poll.
+// device before returning. That cost is unavoidable, but the bounded retry
+// policy permits it at most three times per physical connection rather than
+// on every idle poll.
 // Note: after PORT_RESET the downstream device answers at address 0; the hub
 // itself keeps its address, so core_enumerate's address-0 phase is
 // unambiguous. Deliberately no hcd_bus_reset here -- that would reset the
@@ -103,15 +125,33 @@ bool usb_hub_poll_drive(usb_device_t *drive) {
     for (uint8_t p = 1; p <= n_ports; p++) {
         uint16_t st, chg;
         if (hub_get_port_status(p, &st, &chg) != HCD_OK) continue;
-        if (chg & PORT_CHG_CONNECTION)
-            hub_clear_port_feature(p, HUB_FEAT_C_PORT_CONNECTION);
-        if (!(st & PORT_STAT_CONNECTION)) { connect_streak[p] = 0; continue; }
+        if (chg & PORT_CHG_CONNECTION) {
+            if (hub_clear_port_feature(p, HUB_FEAT_C_PORT_CONNECTION) != HCD_OK)
+                continue;
+            // A connection-change event while the status is still connected
+            // can be an unplug/replug between polls.  Treat it as a new
+            // device and permit one fresh enumeration attempt.
+            connect_streak[p] = 0;
+            enum_attempts[p] = 0;
+            enum_blocked[p] = false;
+        }
+        if (!(st & PORT_STAT_CONNECTION)) {
+            connect_streak[p] = 0;
+            enum_attempts[p] = 0;
+            enum_blocked[p] = false;
+            continue;
+        }
         if (st & PORT_STAT_LOW_SPEED) { connect_streak[p] = 0; continue; }    // LS not supported
+        if (enum_blocked[p]) continue;
+        if (enum_attempts[p] && !time_reached(enum_retry_at[p])) continue;
         if (++connect_streak[p] < HUB_CONNECT_CONFIRM_POLLS) continue;   // not confirmed yet
         connect_streak[p] = 0;   // reset regardless of outcome below
 
         sleep_ms(100);                              // connect debounce
-        if (hub_set_port_feature(p, HUB_FEAT_PORT_RESET) != HCD_OK) continue;
+        if (hub_set_port_feature(p, HUB_FEAT_PORT_RESET) != HCD_OK) {
+            enum_failed(p);
+            continue;
+        }
         // Wait for reset-complete (C_PORT_RESET), max 500 ms
         absolute_time_t rst_deadline = make_timeout_time_ms(500);
         bool reset_done = false;
@@ -124,10 +164,14 @@ bool usb_hub_poll_drive(usb_device_t *drive) {
             }
             sleep_ms(10);
         }
-        if (!reset_done) continue;
+        if (!reset_done) {
+            enum_failed(p);
+            continue;
+        }
         sleep_ms(20);                               // post-reset recovery
 
-        if (core_enumerate(2, drive) == HCD_OK && drive->cfg.is_msc) {
+        hcd_result_t er = core_enumerate(2, drive);
+        if (er == HCD_OK && drive->cfg.is_msc) {
             drive_port = p;
             // Start the hardware-polled status pipe now that no more
             // EPX control traffic is pending (see note in attach).
@@ -135,6 +179,11 @@ bool usb_hub_poll_drive(usb_device_t *drive) {
                                hub.cfg.hub_int_mps, hub.cfg.hub_int_interval);
             active = true;
             return true;
+        }
+        if (er == HCD_OK) {
+            enum_blocked[p] = true;                 // unsupported non-MSC
+        } else {
+            enum_failed(p);                         // bounded transient retry
         }
     }
     return false;

--- a/bsp/usbhost/usb_hub.c
+++ b/bsp/usbhost/usb_hub.c
@@ -19,6 +19,14 @@ static usb_device_t hub;
 static uint8_t      n_ports;
 static int          drive_port = -1;    // 1-based; -1 = none
 static bool         active;
+// Per-port consecutive-poll counter of "looks connected", indexed 1..n_ports
+// (index 0 unused). Guards against acting on a single momentary/false
+// PORT_STAT_CONNECTION reading -- an unterminated external USB-A port with
+// nothing plugged in can read back as transiently "connected" from
+// electrical noise, and without this the expensive debounce+reset+enumerate
+// attempt below (~100-600 ms) would re-run on every poll forever.
+#define HUB_CONNECT_CONFIRM_POLLS 3
+static uint8_t      connect_streak[8];
 
 static hcd_result_t hub_set_port_feature(uint8_t port, uint8_t feature) {
     const uint8_t setup[8] = {0x23, 3, feature, 0, port, 0, 0, 0};
@@ -46,6 +54,7 @@ static hcd_result_t hub_get_port_status(uint8_t port, uint16_t *status,
 hcd_result_t usb_hub_attach(const usb_device_t *dev) {
     hub = *dev;
     drive_port = -1;
+    for (size_t i = 0; i < sizeof connect_streak; i++) connect_streak[i] = 0;
 
     // Hub descriptor (class type 0x29): bNbrPorts at offset 2,
     // bPwrOn2PwrGood (2 ms units) at offset 5
@@ -80,52 +89,55 @@ hcd_result_t usb_hub_attach(const usb_device_t *dev) {
     return HCD_OK;
 }
 
-// Scan ports for a connected FS device; reset it; enumerate it at address 2.
+// Scan ports ONCE for a connected FS device; if found, reset it and enumerate
+// it at address 2. Non-blocking when nothing is connected (just a handful of
+// quick control transfers, no sleep_ms). When a device IS connected, runs the
+// bounded (~0.6 s worst case) debounce/reset/recovery sequence for that one
+// device before returning -- that cost is unavoidable and only paid once per
+// real attach, not on every idle poll.
 // Note: after PORT_RESET the downstream device answers at address 0; the hub
 // itself keeps its address, so core_enumerate's address-0 phase is
 // unambiguous. Deliberately no hcd_bus_reset here -- that would reset the
 // hub too; the port reset already reset the device.
-hcd_result_t usb_hub_wait_drive(usb_device_t *drive, uint32_t timeout_ms) {
-    absolute_time_t deadline = make_timeout_time_ms(timeout_ms);
-    while (!time_reached(deadline)) {
-        for (uint8_t p = 1; p <= n_ports; p++) {
-            uint16_t st, chg;
-            if (hub_get_port_status(p, &st, &chg) != HCD_OK) continue;
-            if (chg & PORT_CHG_CONNECTION)
-                hub_clear_port_feature(p, HUB_FEAT_C_PORT_CONNECTION);
-            if (!(st & PORT_STAT_CONNECTION)) continue;
-            if (st & PORT_STAT_LOW_SPEED) continue;    // LS not supported
+bool usb_hub_poll_drive(usb_device_t *drive) {
+    for (uint8_t p = 1; p <= n_ports; p++) {
+        uint16_t st, chg;
+        if (hub_get_port_status(p, &st, &chg) != HCD_OK) continue;
+        if (chg & PORT_CHG_CONNECTION)
+            hub_clear_port_feature(p, HUB_FEAT_C_PORT_CONNECTION);
+        if (!(st & PORT_STAT_CONNECTION)) { connect_streak[p] = 0; continue; }
+        if (st & PORT_STAT_LOW_SPEED) { connect_streak[p] = 0; continue; }    // LS not supported
+        if (++connect_streak[p] < HUB_CONNECT_CONFIRM_POLLS) continue;   // not confirmed yet
+        connect_streak[p] = 0;   // reset regardless of outcome below
 
-            sleep_ms(100);                              // connect debounce
-            if (hub_set_port_feature(p, HUB_FEAT_PORT_RESET) != HCD_OK) continue;
-            // Wait for reset-complete (C_PORT_RESET), max 500 ms
-            absolute_time_t rst_deadline = make_timeout_time_ms(500);
-            bool reset_done = false;
-            while (!time_reached(rst_deadline)) {
-                if (hub_get_port_status(p, &st, &chg) != HCD_OK) break;
-                if (chg & (1u << 4)) {                  // C_PORT_RESET
-                    hub_clear_port_feature(p, HUB_FEAT_C_PORT_RESET);
-                    reset_done = true;
-                    break;
-                }
-                sleep_ms(10);
+        sleep_ms(100);                              // connect debounce
+        if (hub_set_port_feature(p, HUB_FEAT_PORT_RESET) != HCD_OK) continue;
+        // Wait for reset-complete (C_PORT_RESET), max 500 ms
+        absolute_time_t rst_deadline = make_timeout_time_ms(500);
+        bool reset_done = false;
+        while (!time_reached(rst_deadline)) {
+            if (hub_get_port_status(p, &st, &chg) != HCD_OK) break;
+            if (chg & (1u << 4)) {                  // C_PORT_RESET
+                hub_clear_port_feature(p, HUB_FEAT_C_PORT_RESET);
+                reset_done = true;
+                break;
             }
-            if (!reset_done) continue;
-            sleep_ms(20);                               // post-reset recovery
-
-            if (core_enumerate(2, drive) == HCD_OK && drive->cfg.is_msc) {
-                drive_port = p;
-                // Start the hardware-polled status pipe now that no more
-                // EPX control traffic is pending (see note in attach).
-                hcd_int_ep_install(hub.addr, hub.cfg.hub_int_ep,
-                                   hub.cfg.hub_int_mps, hub.cfg.hub_int_interval);
-                active = true;
-                return HCD_OK;
-            }
+            sleep_ms(10);
         }
-        sleep_ms(50);
+        if (!reset_done) continue;
+        sleep_ms(20);                               // post-reset recovery
+
+        if (core_enumerate(2, drive) == HCD_OK && drive->cfg.is_msc) {
+            drive_port = p;
+            // Start the hardware-polled status pipe now that no more
+            // EPX control traffic is pending (see note in attach).
+            hcd_int_ep_install(hub.addr, hub.cfg.hub_int_ep,
+                               hub.cfg.hub_int_mps, hub.cfg.hub_int_interval);
+            active = true;
+            return true;
+        }
     }
-    return HCD_ERR_TIMEOUT;
+    return false;
 }
 
 // Called from usb_msc_task() while READY: consume hub status-change reports

--- a/bsp/usbhost/usb_hub.h
+++ b/bsp/usbhost/usb_hub.h
@@ -8,10 +8,11 @@ hcd_result_t usb_hub_attach(const usb_device_t *hub);
 // blocking sequence, but only runs when a device is actually present). Returns
 // true + fills *drive on success. Returns false immediately (no sleep_ms) when
 // nothing is connected yet -- call again on the next usb_msc_task() tick; the
-// caller owns the overall wait timeout. Replaces the old usb_hub_wait_drive(),
-// which blocked the whole caller for up to timeout_ms (see AGENTS.md/repo
-// memory: this stalled the wilicankit LVGL+touch loop for ~5s at a time
-// whenever a hub was attached with no drive behind it).
+// caller may wait indefinitely for a connection. Transient reset/enumeration
+// failures receive a bounded set of backed-off retries; a non-MSC device, or a
+// device that exhausts those retries, is ignored until it reconnects. Replaces
+// the old usb_hub_wait_drive(), which blocked the whole caller for up to
+// timeout_ms whenever a hub was attached with no drive behind it.
 bool         usb_hub_poll_drive(usb_device_t *drive);
 bool         usb_hub_drive_present(void);
 void         usb_hub_detach(void);

--- a/bsp/usbhost/usb_hub.h
+++ b/bsp/usbhost/usb_hub.h
@@ -3,6 +3,15 @@
 
 // Single-port hub passthrough (implemented in Task 10).
 hcd_result_t usb_hub_attach(const usb_device_t *hub);
-hcd_result_t usb_hub_wait_drive(usb_device_t *drive, uint32_t timeout_ms);
+// Non-blocking: does ONE pass over the hub's ports looking for a connected FS
+// device, and if found, resets + enumerates it (that part is a bounded ~0.6 s
+// blocking sequence, but only runs when a device is actually present). Returns
+// true + fills *drive on success. Returns false immediately (no sleep_ms) when
+// nothing is connected yet -- call again on the next usb_msc_task() tick; the
+// caller owns the overall wait timeout. Replaces the old usb_hub_wait_drive(),
+// which blocked the whole caller for up to timeout_ms (see AGENTS.md/repo
+// memory: this stalled the wilicankit LVGL+touch loop for ~5s at a time
+// whenever a hub was attached with no drive behind it).
+bool         usb_hub_poll_drive(usb_device_t *drive);
 bool         usb_hub_drive_present(void);
 void         usb_hub_detach(void);

--- a/bsp/usbhost/usb_msc.c
+++ b/bsp/usbhost/usb_msc.c
@@ -176,9 +176,9 @@ void usb_msc_task(void) {
             // Hub passthrough (Task 10): find a drive on a hub port,
             // reset it, enumerate it at address 2. Polled non-blockingly
             // from ST_HUB_WAIT below -- don't block the caller here (this
-            // stalled the whole app, e.g. wilicankit's LVGL+touch loop, for
-            // up to 5s at a time whenever a hub was attached with nothing
-            // plugged into it).
+            // stalled the whole app, e.g. an LVGL+touch loop, for up to 5s
+            // at a time whenever a hub was attached with nothing plugged
+            // into it).
             if (usb_hub_attach(&dev) != HCD_OK) {
                 printf("msc: hub attach failed\n");
                 enter_failed();

--- a/bsp/usbhost/usb_msc.c
+++ b/bsp/usbhost/usb_msc.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include "pico/stdlib.h"
 
-typedef enum { ST_DISCONNECTED, ST_READY, ST_FAILED } msc_state_t;
+typedef enum { ST_DISCONNECTED, ST_HUB_WAIT, ST_READY, ST_FAILED } msc_state_t;
 
 static msc_state_t  state = ST_DISCONNECTED;
 static usb_device_t drive;          // the MSC device (addr 1 direct, 2 via hub)
@@ -135,6 +135,7 @@ static msc_result_t scsi_bringup(void) {
 // ---------------------------------------------------------------------------
 
 static absolute_time_t failed_retry_at;
+static absolute_time_t hub_poll_at;   // ST_HUB_WAIT: throttle usb_hub_poll_drive() calls
 
 static void teardown(void) {
     state = ST_DISCONNECTED;
@@ -173,18 +174,19 @@ void usb_msc_task(void) {
 
         if (dev.cfg.is_hub) {
             // Hub passthrough (Task 10): find a drive on a hub port,
-            // reset it, enumerate it at address 2.
+            // reset it, enumerate it at address 2. Polled non-blockingly
+            // from ST_HUB_WAIT below -- don't block the caller here (this
+            // stalled the whole app, e.g. wilicankit's LVGL+touch loop, for
+            // up to 5s at a time whenever a hub was attached with nothing
+            // plugged into it).
             if (usb_hub_attach(&dev) != HCD_OK) {
                 printf("msc: hub attach failed\n");
                 enter_failed();
                 return;
             }
-            if (usb_hub_wait_drive(&drive, 5000) != HCD_OK) {
-                printf("msc: no drive found behind hub\n");
-                enter_failed();
-                return;
-            }
-            via_hub = true;
+            hub_poll_at = make_timeout_time_ms(50);
+            state = ST_HUB_WAIT;
+            return;
         } else if (dev.cfg.is_msc) {
             drive = dev;
             via_hub = false;
@@ -204,6 +206,29 @@ void usb_msc_task(void) {
         }
         return;
     }
+    case ST_HUB_WAIT:
+        // The CH334F hub is always on-board, so "attached with nothing
+        // plugged into it" is the normal idle state, not a failure -- stay
+        // here indefinitely (just watching port status at a throttled ~50 ms
+        // cadence) instead of tearing down and re-doing the whole bus
+        // reset/enumerate/hub-attach sequence every retry, which is what
+        // caused the remaining periodic ~100-300 ms main-loop stalls.
+        if (hcd_port_speed() == HCD_SPEED_NONE) { teardown(); return; }
+        if (!time_reached(hub_poll_at)) return;
+        hub_poll_at = make_timeout_time_ms(50);
+        if (usb_hub_poll_drive(&drive)) {
+            via_hub = true;
+            toggle_in = toggle_out = 0;
+            msc_result_t br = scsi_bringup();
+            if (br == MSC_OK) {
+                state = ST_READY;
+            } else {
+                printf("msc: scsi bring-up failed (%d), sense=%06lx\n",
+                       (int)br, (unsigned long)last_sense);
+                enter_failed();
+            }
+        }
+        return;
     case ST_READY:
         if (hcd_port_speed() == HCD_SPEED_NONE) { teardown(); return; }
         if (via_hub && !usb_hub_drive_present()) { teardown(); return; }

--- a/docs/drivers/usbhost.md
+++ b/docs/drivers/usbhost.md
@@ -27,7 +27,7 @@ on WiliIR 2026-07-05/06 and again here via `apps/hello_usbdrive`.
   hub passthrough is the *normal* path, not an edge case), a blocking
   multi-second wait here previously stalled the whole app's main loop any
   time nothing was plugged into the external USB-A port — fatal for apps
-  polling touch/LVGL in the same loop (see `apps/wilicankit`). A second hub
+  polling touch/LVGL in the same loop. A second hub
   tier (a hub plugged into the CH334F) is out of scope — not implemented, not
   tested.
 - **`usb_msc`** — BOT transport + the hotplug/enumeration state machine

--- a/docs/drivers/usbhost.md
+++ b/docs/drivers/usbhost.md
@@ -16,12 +16,19 @@ on WiliIR 2026-07-05/06 and again here via `apps/hello_usbdrive`.
   clearing. Uses the SIE directly, no TinyUSB.
 - **`usb_hub`** — single-tier hub passthrough only: `usb_hub_attach()` finds a
   drive behind the CH334F, resets its port, and enumerates the drive at
-  address 2; `usb_hub_wait_drive()` / `usb_hub_drive_present()` poll port
-  status change bits for attach/detach. A second hub tier (a hub plugged into
-  the CH334F) is out of scope — not implemented, not tested.
+  address 2; `usb_hub_poll_drive()` does one non-blocking pass over the
+  CH334F's ports per call (`usb_msc_task()`'s `ST_HUB_WAIT` state re-polls it
+  every tick against its own timeout) and `usb_hub_drive_present()` polls port
+  status change bits for detach. Since the CH334F is always on-board (i.e.
+  hub passthrough is the *normal* path, not an edge case), a blocking
+  multi-second wait here previously stalled the whole app's main loop any
+  time nothing was plugged into the external USB-A port — fatal for apps
+  polling touch/LVGL in the same loop (see `apps/wilicankit`). A second hub
+  tier (a hub plugged into the CH334F) is out of scope — not implemented, not
+  tested.
 - **`usb_msc`** — BOT transport + the hotplug/enumeration state machine
-  (`ST_DISCONNECTED` → `ST_READY` / `ST_FAILED`), SCSI bring-up (INQUIRY +
-  READ CAPACITY), block read/write. **3-tier recovery:** tier 1 is per-command
+  (`ST_DISCONNECTED` → `ST_HUB_WAIT` → `ST_READY` / `ST_FAILED`), SCSI
+  bring-up (INQUIRY + READ CAPACITY), block read/write. **3-tier recovery:** tier 1 is per-command
   retry-once on a stalled CSW; tier 2 is `bot_reset_recovery()` (Bulk-Only
   Mass Storage Reset + clear both endpoint halts) on a transport-level
   failure; tier 3 is `enter_failed()` → full `teardown()` and re-enumerate

--- a/docs/drivers/usbhost.md
+++ b/docs/drivers/usbhost.md
@@ -18,7 +18,11 @@ on WiliIR 2026-07-05/06 and again here via `apps/hello_usbdrive`.
   drive behind the CH334F, resets its port, and enumerates the drive at
   address 2; `usb_hub_poll_drive()` does one non-blocking pass over the
   CH334F's ports per call (`usb_msc_task()`'s `ST_HUB_WAIT` state re-polls it
-  every tick against its own timeout) and `usb_hub_drive_present()` polls port
+  about every 50 ms while waiting indefinitely for a connection). Transient
+  reset/enumeration failures receive a bounded set of backed-off retries;
+  non-MSC devices and devices that exhaust those retries are ignored until
+  they reconnect.
+  `usb_hub_drive_present()` polls port
   status change bits for detach. Since the CH334F is always on-board (i.e.
   hub passthrough is the *normal* path, not an edge case), a blocking
   multi-second wait here previously stalled the whole app's main loop any


### PR DESCRIPTION
usb_hub_wait_drive() blocked the entire caller for up to 5s scanning for a drive behind the on-board CH334F hub. Since the hub is always on-board (hub passthrough is the normal path, not an edge case), this stalled the whole main loop (LVGL/touch/etc, e.g. apps/wilicankit) any time nothing was plugged into the external USB-A port, repeating on usb_msc's 2s failed-retry cadence.

Replace it with usb_hub_poll_drive(): one non-blocking pass over the hub's ports per call, with a per-port connect-streak debounce (HUB_CONNECT_CONFIRM_POLLS) to avoid reacting to a single noisy connected reading. usb_msc_task() gains a new ST_HUB_WAIT state (between ST_DISCONNECTED and ST_READY) that re-polls at a throttled ~50ms cadence instead of blocking synchronously inside ST_DISCONNECTED.