### PR TITLE
feat: enforce display-app rules in the build and tools instead of documenting them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
 # AGENTS.md — guide for AI agents and contributors
 
+> **Consuming wilibsp from another project?** Read
+> **[docs/consuming.md](docs/consuming.md)** instead — it is short, and it is
+> the whole of what a parent project needs. This file is the deep reference for
+> working **on** wilibsp, and about 60 % of it is internal to that job.
+>
+> Do not copy rules out of either file into your own project's docs. Anything
+> copied is pinned to the submodule commit you copied it at and rots silently
+> when you bump it; the enforceable rules already ship as build checks and CLI
+> behaviour that version with the code.
+
 This file orients coding agents (Claude Code, Cursor, Copilot, etc.) and new
 human contributors working in `wilibsp`. It is intentionally dense: the goal
 is that you do **not** have to rediscover the hard-won facts this project was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,9 @@
 # CLAUDE.md
 
 This repo's agent guidance lives in [AGENTS.md](./AGENTS.md). Read it first.
+
+If you are **consuming** wilibsp from a parent project rather than editing it,
+read [docs/consuming.md](./docs/consuming.md) instead — it is short and covers
+the whole contract. AGENTS.md is 450 lines and mostly internal to wilibsp
+development, which makes it easy to skim past the parts that would have
+mattered to you.

--- a/apps/template/CMakeLists.txt
+++ b/apps/template/CMakeLists.txt
@@ -2,5 +2,23 @@
 # rewrites every 'template' occurrence to the new app name.
 add_executable(template main.c)
 target_link_libraries(template freewili2_bsp)
-pico_set_binary_type(template copy_to_ram)   # required: firmware runs from SRAM
-pico_add_extra_outputs(template)             # .uf2 / .bin / .map
+
+# Where this app runs. `fw new-app <name> --window <w>` rewrites the token
+# below; everything that follows from the choice is handled for you.
+#
+#   FLASH  written to the display's QSPI flash and run from there
+#          (copy_to_ram). Programmed over SWD with `fw flash`. This REPLACES
+#          the stock display firmware, FW2Display -- fine for BSP development,
+#          never for the SD card.
+#   SRAM   staged into SRAM by the fused bootloader. Loadable from the SD
+#          card's /apps/, launched with `fw run-app`, flash untouched.
+#   PSRAM  staged into the 8 MB window at 0x11000000 by FW2PsramStub. Same
+#          non-destructive launch surface as SRAM, with far more room. The
+#          PSRAM-specific boot requirements -- moving the XIP window, skipping
+#          the SDK's PSRAM re-init, sparing the bank-0 pad that carries XIP
+#          CS1, and emitting a UF2 picotool refuses to make -- are all applied
+#          by fw2_finalize_app(); do not hand-roll them.
+#
+# Whichever you pick, the built UF2 is verified against it on every build, so
+# an app cannot silently end up targeting a window it did not declare.
+fw2_finalize_app(template FLASH)

--- a/bsp/CMakeLists.txt
+++ b/bsp/CMakeLists.txt
@@ -1,4 +1,11 @@
 # freewili2_bsp — shared board-support library (STATIC once it has sources).
+
+# App target configuration + enforcement. Included first so the board guard runs
+# before anything is built, and so consumers get fw2_finalize_app() simply by
+# doing add_subdirectory(wilibsp/bsp) -- no extra wiring, and it versions with
+# the submodule instead of being copied into each project's docs.
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/fw2_app.cmake)
+
 add_library(freewili2_bsp STATIC
     agentio/agentio.c
     agentio/agentio_rle.c

--- a/bsp/agentio/agentio.c
+++ b/bsp/agentio/agentio.c
@@ -85,6 +85,14 @@ static bool     s_tap_active;
 static uint32_t s_tap_deadline;
 static uint32_t s_tap_reads0;
 
+/* Set while the app is inside a region whose timing is the result; see
+ * agentio_measure_begin() in agentio.h. Only captures are gated on it --
+ * injection is cheap and is often what starts the measured work. */
+static volatile bool s_measuring;
+
+void agentio_measure_begin(void) { s_measuring = true; }
+void agentio_measure_end(void)   { s_measuring = false; }
+
 /* One output row at a time, sized to the widest surface we can be asked for.
  * Derive it rather than hard-coding 480: HSTX_VID_W_MAX is overridable by a
  * target compile definition (see bsp/display/hstx_dvi.h), so an app that raises
@@ -369,6 +377,15 @@ static void dispatch(char *line)
          * so the host knows to retry rather than silently racing it. */
         if (s_q_count > 0 || s_type[s_type_pos] != 0) {
             reply("ERR busy\n");
+            return;
+        }
+        /* A capture streams the whole shadow from this main loop. Inside a
+         * timed region that cost lands between the app's measurements instead
+         * of inside them, so its own timing looks fine while wall-clock
+         * throughput collapses -- see agentio_measure_begin() in agentio.h.
+         * Refuse rather than silently corrupt the result. */
+        if (s_measuring) {
+            reply("ERR measuring\n");
             return;
         }
         do_capture((int)strtol(argv[1], 0, 10), (int)strtol(argv[2], 0, 10),

--- a/bsp/agentio/agentio.h
+++ b/bsp/agentio/agentio.h
@@ -40,6 +40,25 @@ void agentio_shadow_note_pixels(const uint8_t *bytes, size_t n);
  * pixel, MSB first). NULL when the module is disabled. */
 const uint8_t *agentio_shadow_fb(void);
 
+/* Mark a region whose TIMING is the result.
+ *
+ * agentio is not a free observer. A capture RLE-encodes and streams the whole
+ * shadow -- 307,200 bytes for the LCD -- out over RTT from the app's own main
+ * loop. That cost lands BETWEEN whatever the app is timing rather than inside
+ * it, so the app's own microsecond accounting misses it entirely while
+ * wall-clock throughput collapses. A downstream benchmark published figures 5x
+ * and 15x low this way, and the wrong numbers were written up as a hardware
+ * finding before anyone noticed a `fw rtt` session had been attached.
+ *
+ * Wrap a timed region in these and a capture arriving mid-measurement is
+ * refused with "ERR measuring" instead of silently corrupting it. Input
+ * injection is unaffected -- it is cheap, and it is often how a run gets
+ * started in the first place.
+ *
+ * Nesting is not supported: end() clears the flag regardless of depth. */
+void agentio_measure_begin(void);
+void agentio_measure_end(void);
+
 #else
 
 static inline void agentio_init(void) {}
@@ -50,6 +69,8 @@ static inline void agentio_shadow_note_window(int x0, int y0, int x1, int y1)
 static inline void agentio_shadow_note_pixels(const uint8_t *b, size_t n)
 { (void)b; (void)n; }
 static inline const uint8_t *agentio_shadow_fb(void) { return 0; }
+static inline void agentio_measure_begin(void) {}
+static inline void agentio_measure_end(void) {}
 
 #endif /* FW2_AGENTIO */
 

--- a/bsp/cmake/fw2_app.cmake
+++ b/bsp/cmake/fw2_app.cmake
@@ -1,0 +1,125 @@
+# fw2_app.cmake — app target configuration and enforcement for the FreeWili 2
+# display CPU. Included by bsp/CMakeLists.txt, so it runs inside the consumer's
+# configure step and applies to consumer targets.
+#
+# WHY THIS FILE EXISTS
+#
+# Most of what a consumer project used to have to know about building a display
+# app was prose in AGENTS.md, re-read and re-applied by hand in every project.
+# That does not hold. One downstream project reasoned its way past the "/apps/
+# may never target flash" rule and overwrote the stock DISPLAY firmware; another
+# rediscovered the PSRAM-app boot requirements from scratch over two sessions.
+# Both were documented. Neither was enforced.
+#
+# So: a rule that can be enforced is not written down here, it is executed. The
+# entry point is
+#
+#     fw2_finalize_app(<target> <SRAM|PSRAM|FLASH>)
+#
+# which picks the binary type, applies whatever that window needs, emits the
+# UF2, and then verifies the artifact actually matches the window it claims.
+# The consumer declares intent once; the rules follow from it.
+
+set(FW2_APP_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "fw2_app.cmake dir")
+set(FW2_TOOLS_DIR "${CMAKE_CURRENT_LIST_DIR}/../../tools" CACHE INTERNAL "wilibsp tools dir")
+
+# --- Board guard (AGENTS.md invariants 1 and 8) -----------------------------
+#
+# `-DPICO_BOARD=...` on the command line overrides the cached value the parent
+# project sets and silently reverts the build to the RP2350A config: 30 GPIO
+# instead of 48, so every pin above 29 is wrong and the failure shows up as
+# dead peripherals, not as a build error. Checking the value catches it however
+# it got there.
+if(NOT PICO_BOARD STREQUAL "freewili2")
+    message(FATAL_ERROR
+        "PICO_BOARD is '${PICO_BOARD}', must be 'freewili2'.\n"
+        "  The FreeWili 2 is an RP2350B (48 GPIO). Any other board header selects "
+        "the RP2350A pin count and every GPIO above 29 silently becomes wrong.\n"
+        "  Set it in your top-level CMakeLists.txt:\n"
+        "      set(PICO_BOARD freewili2 CACHE STRING \"Board type\")\n"
+        "  and do NOT pass -DPICO_BOARD on the cmake command line -- that "
+        "overrides the cached value.")
+endif()
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+# --- fw2_finalize_app -------------------------------------------------------
+#
+#   fw2_finalize_app(<target> SRAM)    staged into SRAM by the fused bootloader
+#   fw2_finalize_app(<target> PSRAM)   staged into the 8 MB window by FW2PsramStub
+#   fw2_finalize_app(<target> FLASH)   written to flash; REPLACES FW2Display
+#
+# SRAM and PSRAM are the two non-destructive `/apps/` launch surfaces. FLASH is
+# for `fw flash` over SWD during BSP development and is deliberately awkward to
+# reach by accident.
+function(fw2_finalize_app TARGET WINDOW)
+    if(NOT TARGET ${TARGET})
+        message(FATAL_ERROR "fw2_finalize_app: '${TARGET}' is not a target")
+    endif()
+
+    if(WINDOW STREQUAL "PSRAM")
+        # A PSRAM app is an ordinary XIP image whose execute-in-place window is
+        # the APS6404L on QMI CS1 at 0x11000000 rather than the flash on CS0.
+        # NOT no_flash, NOT copy_to_ram -- the default binary type, relocated.
+        pico_add_linker_script_override_path(${TARGET}
+            ${FW2_APP_CMAKE_DIR}/psram_app_ld
+            FILES pico_flash_region.ld pico_psram_region.ld)
+
+        # The app enters with PSRAM already brought up by the stub and EXECUTES
+        # from that window. The board header defines PICO_PSRAM_CS_PIN, which
+        # arms the SDK's runtime_init_setup_psram -- that would re-time the
+        # memory the next instruction is fetched from, before main(). The PSRAM
+        # app contract forbids exactly this. (AGENTS.md invariant 12.)
+        target_compile_definitions(${TARGET} PRIVATE
+            FW2_PSRAM_APP=1
+            PICO_RUNTIME_SKIP_INIT_PSRAM=1)
+
+        # Added to the APP, not the BSP archive: this overrides a weak SDK
+        # symbol, and a definition sitting in a static library is not guaranteed
+        # to displace one the linker has already resolved.
+        target_sources(${TARGET} PRIVATE
+            ${FW2_APP_CMAKE_DIR}/../platform/psram_app_runtime.c)
+
+        # picotool refuses the PSRAM window ("entry point is not in mapped part
+        # of file") because 0x11000000 is not a device range it knows, so
+        # pico_add_extra_outputs is unusable here. The .bin is fine; wrap it.
+        add_custom_command(TARGET ${TARGET} POST_BUILD
+            COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${TARGET}>
+                    $<TARGET_FILE_DIR:${TARGET}>/${TARGET}.bin
+            COMMAND ${Python3_EXECUTABLE} ${FW2_TOOLS_DIR}/bin2uf2.py
+                    $<TARGET_FILE_DIR:${TARGET}>/${TARGET}.bin
+                    $<TARGET_FILE_DIR:${TARGET}>/${TARGET}.uf2
+                    --base 0x11000000 --family rp2350-arm-s
+            VERBATIM)
+        set(_win psram)
+
+    elseif(WINDOW STREQUAL "SRAM")
+        pico_set_binary_type(${TARGET} no_flash)
+        pico_add_extra_outputs(${TARGET})
+        set(_win sram)
+
+    elseif(WINDOW STREQUAL "FLASH")
+        pico_set_binary_type(${TARGET} copy_to_ram)
+        pico_add_extra_outputs(${TARGET})
+        set(_win flash)
+        message(WARNING
+            "${TARGET} is a FLASH app: installing it REPLACES the stock DISPLAY "
+            "firmware (FW2Display).\n"
+            "  This is correct for `fw flash` over SWD. It must NOT be copied to "
+            "/apps/ on the SD card -- that surface is SRAM/PSRAM only.\n"
+            "  If you wanted a loadable app, use SRAM or PSRAM instead.")
+
+    else()
+        message(FATAL_ERROR
+            "fw2_finalize_app(${TARGET} ${WINDOW}): window must be one of "
+            "SRAM, PSRAM, FLASH")
+    endif()
+
+    # Verify the artifact against the window it claims, every build. Catches a
+    # binary type that does not match the declared intent, an image that is not
+    # based at the window, and a vector table that would not launch.
+    add_custom_command(TARGET ${TARGET} POST_BUILD
+        COMMAND ${Python3_EXECUTABLE} ${FW2_TOOLS_DIR}/uf2check.py
+                $<TARGET_FILE_DIR:${TARGET}>/${TARGET}.uf2 --window ${_win}
+        VERBATIM)
+endfunction()

--- a/bsp/cmake/psram_app_ld/pico_flash_region.ld
+++ b/bsp/cmake/psram_app_ld/pico_flash_region.ld
@@ -1,0 +1,16 @@
+/* PSRAM-app override: put the "flash" (XIP) region in PSRAM.
+ *
+ * A FreeWili 2 display PSRAM app is structurally an ordinary XIP image whose
+ * execute-in-place window is the 8 MB APS6404L on QMI CS1 at 0x11000000 rather
+ * than the flash on CS0 at 0x10000000. Everything else about the default layout
+ * is right: .text/.rodata execute from the window, crt0 copies .data to SRAM,
+ * and __not_in_flash_func() still lands hot code in SRAM at boot.
+ *
+ * Why not a RAM app: the fused UART bootloader stages only
+ * BL_STAGE_BYTES = 192 KiB in one shot (a RAM load never sends 'F', so the
+ * shell never flips its staging halves). That is the real ceiling -- NOT the
+ * 448 KiB BL_LOAD_SIZE_MAX the loader handoff doc quotes -- and this app's
+ * ~257 KiB image is refused by both `a\r` and `h\v\a` with "image too large".
+ * FW2PsramStub stages into this window instead and has the whole 8 MB.
+ */
+FLASH(rx) : ORIGIN = 0x11000000, LENGTH = (8 * 1024 * 1024)

--- a/bsp/cmake/psram_app_ld/pico_psram_region.ld
+++ b/bsp/cmake/psram_app_ld/pico_psram_region.ld
@@ -1,0 +1,12 @@
+/* PSRAM-app override: retire the separate PSRAM region.
+ *
+ * The default layout declares PSRAM(rwx) at 0x11000000 for the SDK's optional
+ * .psram_load/.psram_noload sections. For a PSRAM app that same address IS the
+ * XIP region (see pico_flash_region.ld), so leaving both at 0x11000000 gives
+ * two regions claiming one address, and the empty .psram_* output sections
+ * would be placed on top of the vector table.
+ *
+ * Length 0 keeps the region defined -- sections_psram.incl still references it
+ * -- while making it impossible to place anything there by accident.
+ */
+PSRAM(rwx) : ORIGIN = 0x11000000, LENGTH = 0

--- a/bsp/platform/psram_app_runtime.c
+++ b/bsp/platform/psram_app_runtime.c
@@ -1,0 +1,67 @@
+/* Runtime-init override for a FreeWili 2 display PSRAM app.
+ *
+ * An app executing from the 0x11000000 PSRAM window has the same constraint a
+ * flash app has -- do not disturb the memory you are fetching instructions
+ * from -- but the SDK only knows about the flash case.
+ *
+ * pico_runtime_init/runtime_init.c spares the QSPI pads when it resets
+ * peripherals, because flash lives on the dedicated QSPI pads. The FreeWili 2's
+ * PSRAM is an APS6404L on QMI CS1 whose chip select is GPIO47 -- an ordinary
+ * BANK-0 pin, muxed to GPIO_FUNC_XIP_CS1 by whoever brought the PSRAM up
+ * (FW2PsramStub, here). RESET_IO_BANK0 / RESET_PADS_BANK0 are NOT spared, so
+ * runtime_init_early_resets() reverts GPIO47 to its default function and the
+ * window stops decoding, mid runtime-init -- before main(), before even the
+ * static constructors. The core ends up in LOCKUP rather than reporting a
+ * HardFault, because VTOR still points at the loader stub's vector table.
+ *
+ * The fix is to spare the IO bank the PSRAM chip select lives in, exactly as
+ * the SDK already spares the QSPI pads for flash. Diagnosis and the
+ * tried-and-reverted alternative (un-muxing GPIO47 and restoring it by hand --
+ * the window does not survive being un-muxed even briefly) are recorded in
+ * fw2_nes: piconesPlus/pico_shared/fw2_psram_runtime.c.
+ *
+ * KNOWN COST: every bank-0 pad keeps whatever the loader stub left it as. In
+ * fw2_nes that left the I2C1 devices unreachable -- and this app needs two of
+ * them (the PCAL6524 expander, which releases the LCD reset per wilibsp
+ * invariant 7, and the FT6336 touch controller). Unlike fw2_nes, the stock
+ * display firmware runs before the launch and configures both, so they may
+ * already be in a working state; if not, the recovery is to restore the GPIO
+ * 26/27 pad state by hand before board_i2c1_init().
+ */
+#if FW2_PSRAM_APP
+
+#include "hardware/resets.h"
+#include "pico/runtime_init.h"
+
+/* Mirrors runtime_init_early_resets() from pico_runtime_init, plus
+ * RESET_IO_BANK0 / RESET_PADS_BANK0 in the spared set. Kept in SRAM so no part
+ * of it is fetched through the window it is protecting. */
+void __no_inline_not_in_flash_func(runtime_init_early_resets)(void) {
+    reset_block_mask(~(
+            (1u << RESET_IO_QSPI) |
+            (1u << RESET_PADS_QSPI) |
+            /* --- PSRAM app: XIP CS1 is GPIO47, a bank-0 pin. Resetting these
+             * two un-muxes it and kills the window we execute from. --- */
+            (1u << RESET_IO_BANK0) |
+            (1u << RESET_PADS_BANK0) |
+            /* --- end addition --- */
+            (1u << RESET_PLL_USB) |
+            (1u << RESET_USBCTRL) |
+            (1u << RESET_SYSCFG) |
+            (1u << RESET_PLL_SYS)
+    ));
+
+    /* Remove reset from peripherals which are clocked only by clk_sys and
+     * clk_ref. Other peripherals stay in reset until clocks are configured. */
+    unreset_block_mask_wait_blocking(RESETS_RESET_BITS & ~(
+            (1u << RESET_HSTX) |
+            (1u << RESET_ADC) |
+            (1u << RESET_SPI0) |
+            (1u << RESET_SPI1) |
+            (1u << RESET_UART0) |
+            (1u << RESET_UART1) |
+            (1u << RESET_USBCTRL)
+    ));
+}
+
+#endif /* FW2_PSRAM_APP */

--- a/docs/consuming.md
+++ b/docs/consuming.md
@@ -1,0 +1,125 @@
+# Consuming wilibsp from another project
+
+Read this if your project pulls `wilibsp` in as a submodule and builds its own
+display app. If you are working **on** wilibsp itself — adding a driver,
+editing the BSP — read [AGENTS.md](../AGENTS.md) instead; it is the deep
+reference and this is not a summary of it.
+
+This file is deliberately short. Most of what used to be documented here is now
+enforced by the build and the CLI, because prose that has to be remembered and
+re-applied by every project does not survive contact with a deadline. What
+remains is the part no check can make for you.
+
+## Wiring it in
+
+```cmake
+set(PICO_BOARD freewili2 CACHE STRING "Board type")     # never -DPICO_BOARD
+list(APPEND PICO_BOARD_HEADER_DIRS "${CMAKE_CURRENT_LIST_DIR}/wilibsp/bsp/boards")
+
+include(pico_sdk_import.cmake)
+project(myproject C CXX ASM)
+pico_sdk_init()
+
+add_subdirectory(wilibsp/bsp)          # also provides fw2_finalize_app()
+add_subdirectory(wilibsp/libs/onewili) # optional: main-CPU + SD access
+add_subdirectory(src)
+```
+
+Then, for your app target:
+
+```cmake
+add_executable(myapp main.c)
+target_link_libraries(myapp freewili2_bsp)
+fw2_finalize_app(myapp PSRAM)          # SRAM | PSRAM | FLASH
+```
+
+**That one call is the whole contract.** Declaring the window applies the
+binary type, any linker overrides, the runtime-init overrides, and the right
+UF2 emission — then verifies on every build that the artifact actually targets
+what you declared. Do not hand-roll `pico_set_binary_type`, linker script
+overrides, or PSRAM boot workarounds; if you find yourself needing to, that is
+a bug in `fw2_finalize_app()` worth reporting rather than working around.
+
+### Which window
+
+| | Where it runs | Deployed by | Touches stock firmware? |
+|---|---|---|---|
+| `SRAM` | staged into SRAM by the fused bootloader | SD card `/apps/` | no |
+| `PSRAM` | 8 MB window at `0x11000000`, staged by FW2PsramStub | SD card `/apps/` | no |
+| `FLASH` | the display's QSPI flash | `fw flash` over SWD | **yes — replaces FW2Display** |
+
+`SRAM` and `PSRAM` are the non-destructive launch surfaces. Prefer them unless
+you are developing the BSP itself. `FLASH` warns at configure time and is
+rejected by `fw install-app`; restoring the stock firmware afterwards means
+reflashing `FW2Display.uf2`.
+
+## Workflow
+
+```sh
+fw install-app build/src/myapp.uf2   # copy to the card's /apps/ (refuses flash images)
+fw run-app myapp.uf2                 # reset the display, launch, report the real result
+fw list-apps                         # what is actually on the card
+
+fw rtt                               # DIAG output (RTT is the only diagnostic channel)
+fw screenshot -o shot.png            # capture the panel
+fw touch <x> <y> / fw press <btn>    # drive the UI
+fw alive                             # is it executing? (does not perturb it)
+fw peek <addr>                       # read memory from a running target
+```
+
+`fw run-app` exists because a bare launch is unreliable in two non-obvious
+ways: the display must be reset first or the fused bootloader will not answer,
+and the real outcome arrives in a deferred frame long after the immediate ack.
+Both are handled for you — use it rather than driving the console yourself.
+
+## The parts nothing can check for you
+
+Everything above is enforced. These are judgment calls:
+
+1. **"GPIO 12" is ambiguous on this board — ask which one.** Display GPIO, main
+   GPIO, and the user header are different pin spaces. Guessing produces code
+   that compiles, runs, and drives the wrong pin. See `docs/hardware/pinmap.md`.
+
+2. **Request power rails before touching a peripheral.** Most rails boot OFF,
+   and the boot-on set is firmware-defined and changes between versions. A
+   driver that reads garbage or returns silence is more often an unpowered rail
+   than a bug. `picpwr_keep_awake(...)`, then wait ~1 s, then init. Full zone
+   map in `docs/drivers/power.md`.
+
+3. **Do not assume a doc describes verified behaviour.** Where this repo says
+   what something does, check whether a file under `docs/superpowers/findings/`
+   backs it. If none does, it is design intent — say so rather than repeating
+   it as fact. This applies to the file you are reading.
+
+4. **Observation is not free, and the debugger is not neutral.** A screenshot
+   RLE-encodes and streams 307,200 bytes from your app's own main loop. Inside
+   a timed region that cost lands *between* your measurements, so your own
+   microsecond accounting looks fine while wall-clock throughput collapses — a
+   downstream benchmark published figures 5x and 15x low exactly this way.
+   Wrap timed regions in `agentio_measure_begin()` / `agentio_measure_end()`
+   and captures will be refused rather than silently corrupting the result.
+
+   The same caution applies to SWD. `fw alive` and `fw peek` are safe by
+   construction; anything that halts a core is not, because the RP2350 pauses
+   TIMER0 while a core is debug-halted and your app's whole timebase stops with
+   it. If a board ever looks hung with a frozen screen but a responsive
+   agentio, that is the signature — `fw thaw`.
+
+5. **Large buffers go in PSRAM via the linker, never by casting `PSRAM_BASE`.**
+   The linker's PSRAM region starts at that same address, so a raw pointer
+   there silently aliases whatever it allocated. Use
+   `__uninitialized_psram("group")`.
+
+## When something does not work
+
+Before believing that a launch failed, check in this order:
+
+1. `fw list-apps` — is the file even on the card?
+2. `fw alive` — is the display CPU executing at all?
+3. `fw rtt` — did the app reach its own DIAG output?
+
+The expensive failure mode in this ecosystem is not a broken board, it is a
+correct-looking observation taken with a tool that changed what it measured.
+Two separate multi-session investigations here reached confident, wrong
+conclusions that way. If a result is surprising, suspect the instrument before
+the hardware.

--- a/tools/bin2uf2.py
+++ b/tools/bin2uf2.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Wrap a raw binary into a UF2 at an arbitrary base address.
+
+    tools/bin2uf2.py <in.bin> <out.uf2> --base 0x11000000
+
+Needed because picotool refuses a PSRAM-window image: `picotool uf2 convert`
+fails with "entry point is not in mapped part of file" for anything based at
+0x11000000, since it only knows about the flash window at 0x10000000 and SRAM.
+The container itself is trivial, so we emit it directly.
+
+Layout per github.com/microsoft/uf2: 512-byte blocks, 32-byte header, up to 476
+payload bytes. 256 is used here, matching what picotool emits for RP2350 and what
+fwImageStream/the fused bootloader are exercised with.
+
+The FreeWili display-app loader classifies on the FIRST block's target address
+(fwDisplayAppLoader::classifyImage), so the base is what routes the image:
+    0x10000000  -> flash
+    0x11000000  -> PSRAM, staged by FW2PsramStub
+    0x20000000  -> SRAM, staged by the fused bootloader (192 KiB ceiling)
+"""
+import argparse
+import struct
+import sys
+
+UF2_MAGIC_START0 = 0x0A324655
+UF2_MAGIC_START1 = 0x9E5D5157
+UF2_MAGIC_END = 0x0AB16F30
+
+UF2_FLAG_FAMILY_ID = 0x00002000
+
+FAMILIES = {
+    "rp2350-arm-s": 0xE48BFF59,
+    "rp2350-arm-ns": 0xE48BFF5B,
+    "rp2350-riscv": 0xE48BFF5A,
+    "rp2040": 0xE48BFF56,
+}
+
+PAYLOAD = 256
+BLOCK = 512
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("src")
+    ap.add_argument("dst")
+    ap.add_argument("--base", required=True,
+                    help="target address of the first byte, e.g. 0x11000000")
+    ap.add_argument("--family", default="rp2350-arm-s", choices=sorted(FAMILIES))
+    args = ap.parse_args(argv)
+
+    base = int(args.base, 0)
+    family = FAMILIES[args.family]
+
+    with open(args.src, "rb") as f:
+        data = f.read()
+    if not data:
+        sys.exit("empty input")
+
+    # Pad the tail so every block carries a full payload; the loader pads to 128
+    # on the wire anyway and a short final block is legal but pointless.
+    if len(data) % PAYLOAD:
+        data += b"\x00" * (PAYLOAD - len(data) % PAYLOAD)
+
+    nblocks = len(data) // PAYLOAD
+    with open(args.dst, "wb") as out:
+        for i in range(nblocks):
+            chunk = data[i * PAYLOAD:(i + 1) * PAYLOAD]
+            hdr = struct.pack("<8I",
+                              UF2_MAGIC_START0, UF2_MAGIC_START1,
+                              UF2_FLAG_FAMILY_ID,
+                              base + i * PAYLOAD,
+                              PAYLOAD, i, nblocks, family)
+            out.write(hdr + chunk + b"\x00" * (BLOCK - 32 - PAYLOAD - 4)
+                      + struct.pack("<I", UF2_MAGIC_END))
+
+    print(f"{args.dst}: {nblocks} blocks, {len(data)} payload bytes, "
+          f"0x{base:08X}..0x{base + len(data):08X}, family {args.family}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/fw.py
+++ b/tools/fw.py
@@ -9,6 +9,11 @@ Commands:
   fw test            build+run host unit tests (CTest, no hardware)
   fw new-app <name>  scaffold apps/<name> from apps/template
   fw install-app UF2 copy an app to the device SD card's /apps directory
+  fw run-app <name>  launch /apps/<name> on the display CPU and report the result
+  fw list-apps       list the SD card's /apps directory
+  fw peek <addr>     read memory from the running target (never halts)
+  fw alive           is the display CPU executing? (checks TIMER0 advances)
+  fw thaw            release a debug-halted core that has TIMER0 paused
 Add --print to any build/flash/test command to print the command(s) instead of running.
 """
 import argparse, os, pathlib, shutil, socket, stat, struct, subprocess, sys, time, zlib
@@ -408,6 +413,159 @@ def flash_command(app):
     elf = f"build/apps/{app}/{app}.elf"
     return _openocd_base() + ["-c", f"program {elf} verify reset exit"]
 
+def run_app(name, reset=True, timeout=90.0):
+    r"""Launch /apps/<name> on the display CPU and report the real outcome.
+
+    Two things make the naive `a\r <file>` unreliable, and both are handled here
+    so no caller has to know them:
+
+    1. **The display must be reset first.** Once it is running an app -- or a
+       crashed one -- the fused bootloader does not answer hop 1, and the launch
+       fails with "display bootloader did not answer". `h\v\x` first.
+
+    2. **`a\r` returns a dispatch ack immediately; the real result arrives later
+       in a deferred [d ...] frame.** A two-hop PSRAM stage streams the whole
+       image over the 8 Mbaud link, so a short read window misses it and a
+       *successful* launch looks like it silently did nothing.
+
+    The destination is inferred from the image, not the filename: an SRAM UF2 is
+    staged into RAM, a PSRAM-window one through FW2PsramStub, and anything else
+    is written to FLASH -- which replaces the stock display firmware. Build apps
+    with fw2_finalize_app(SRAM|PSRAM) and that last case cannot arise.
+    """
+    from fw_console import Console
+
+    with Console() as con:
+        if reset:
+            print("resetting display...")
+            _, frames = con.call(r"h\v\x", wait=10.0, idle=3.0)
+            for path, _ts, seq, resp in frames:
+                print(f"  [{path}] seq={seq} {resp.strip()}")
+            time.sleep(5)     # let the fused bootloader come up and listen
+
+        print(f"launching {name}...")
+        _, frames = con.call(rf"a\r {name}", wait=timeout, idle=25.0)
+
+    if not frames:
+        print("no response frame — the launch may still be streaming, or the "
+              "console was lost", file=sys.stderr)
+        return 1
+
+    rc = 0
+    for path, _ts, seq, resp in frames:
+        resp = resp.strip()
+        print(f"  [{path}] seq={seq} {resp}")
+        # The deferred frame carries the verdict. "Ok" means the stub answered,
+        # the image streamed and CRC-verified, and it jumped.
+        if path == "d" and not resp.lower().startswith("ok"):
+            rc = 1
+    if rc:
+        print("\nlaunch FAILED. If the image is on the card and well-formed, the "
+              "usual causes are:\n"
+              "  - the display was already running an app (reset first)\n"
+              "  - the file is not in /apps/ (check with `fw list-apps`)\n"
+              "  - the UF2 targets a window the loader will not stage",
+              file=sys.stderr)
+    return rc
+
+
+def list_apps():
+    r"""Print the card's /apps directory (h\v\l), so a failed launch can be told
+    apart from a missing file."""
+    from fw_console import Console
+    with Console() as con:
+        _, frames = con.call(r"h\v\l", wait=20.0, idle=4.0)
+    if not frames:
+        print("no response frame", file=sys.stderr)
+        return 1
+    for path, _ts, seq, resp in frames:
+        print(f"[{path}] seq={seq} {resp.strip()}")
+    return 0
+
+
+TIMER0_TIMERAWL = 0x400B0028   # free-running microsecond counter, read-to-peek
+
+def peek_command(addr, count):
+    """Read memory from a RUNNING target. `init` + `read_memory`, never `halt`.
+
+    A halt is not a neutral observation on this chip: TIMER0's DBGPAUSE pauses
+    the timer while a core is debug-halted, so halting to look at something
+    stops the app's timebase underneath it. The config defers cm1's examine so
+    that can no longer become permanent, but there is still no reason to halt
+    just to read a word."""
+    return _openocd_base() + [
+        "-c", "init", "-c", f"read_memory 0x{addr:08x} 32 {count}", "-c", "shutdown"]
+
+def _openocd_words(cmd):
+    """Run an OpenOCD command list and collect the hex words it printed.
+
+    OpenOCD logs to stderr -- including `read_memory` results -- so both streams
+    have to be scanned. Info/Error lines are skipped so their addresses and
+    hex ids are not mistaken for data."""
+    out = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True)
+    words = []
+    for stream in (out.stdout, out.stderr):
+        for line in stream.splitlines():
+            if line.startswith(("Info :", "Warn :", "Error:", "Debug:")):
+                continue
+            for w in line.split():
+                try:
+                    words.append(int(w, 16) if w.startswith("0x") else None)
+                except ValueError:
+                    words.append(None)
+    return [w for w in words if w is not None], out
+
+def run_peek(addr, count):
+    words, out = _openocd_words(peek_command(addr, count))
+    if not words:
+        sys.stderr.write(out.stderr)
+        print("peek: no data — is the probe connected?", file=sys.stderr)
+        return 1
+    for i, w in enumerate(words[:count]):
+        print(f"0x{addr + 4 * i:08x}: 0x{w:08x}")
+    return 0
+
+def run_alive():
+    """Is the display CPU executing? Reads TIMER0 twice and looks for movement.
+
+    This is the liveness test that does not perturb what it measures -- no halt,
+    no reset. A frozen counter means the timebase is stopped, which presents as
+    a hung UI (the LVGL tick stops, so redraws and input polling stop) even
+    though the main loop may still be servicing things that need no timer."""
+    wa, _ = _openocd_words(peek_command(TIMER0_TIMERAWL, 1))
+    time.sleep(0.2)
+    wb, _ = _openocd_words(peek_command(TIMER0_TIMERAWL, 1))
+
+    t0 = wa[0] if wa else None
+    t1 = wb[0] if wb else None
+    if t0 is None or t1 is None:
+        print("alive: could not read TIMER0 — is the probe connected?", file=sys.stderr)
+        return 1
+    if t1 != t0:
+        print(f"alive: RUNNING (TIMER0 {t0:#010x} -> {t1:#010x})")
+        return 0
+    print(f"alive: TIMER0 IS FROZEN at {t0:#010x}\n"
+          "  The timebase is stopped, so the LVGL tick and every LVGL timer are\n"
+          "  stopped too: no redraws, no input polling. Anything driven straight\n"
+          "  off the main loop still responds, so this looks like a hung UI.\n"
+          "  Usual cause is a debug-halted core (TIMER0 DBGPAUSE). Try `fw thaw`.",
+          file=sys.stderr)
+    return 1
+
+def run_thaw():
+    """Release a core left debug-halted, which un-pauses TIMER0.
+
+    Should be unnecessary now that the OpenOCD config defers cm1's examine, but
+    a board frozen by an older config (or a hand-rolled `halt`) still needs
+    rescuing, and that does not require relaunching the app."""
+    cmd = _openocd_base() + ["-c", "init",
+                             "-c", "targets rp2350.cm1", "-c", "poll",
+                             "-c", "catch {resume}",
+                             "-c", "targets rp2350.cm0", "-c", "catch {resume}",
+                             "-c", "shutdown"]
+    subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True)
+    return run_alive()
+
 def rtt_command():
     """OpenOCD serving BOTH RTT channels: 0 (DIAG) and 1 (agentio). Only one
     process can own the debug probe, so a running `fw rtt` doubles as the
@@ -642,6 +800,20 @@ def main(argv=None):
     sp.add_argument("--timeout", type=float, default=25,
                     help="seconds to wait for the USB SD reader (default: 25)")
 
+    sp = sub.add_parser("run-app")
+    sp.add_argument("name", help="filename in /apps on the SD card, e.g. myapp.uf2")
+    sp.add_argument("--no-reset", action="store_true",
+                    help="skip the display reset (the launch will usually fail)")
+    sp.add_argument("--timeout", type=float, default=90,
+                    help="seconds to wait for the deferred result frame (default: 90)")
+    sub.add_parser("list-apps")
+
+    sp = sub.add_parser("peek")
+    sp.add_argument("addr", help="address, e.g. 0x20012f44")
+    sp.add_argument("--count", type=int, default=1, help="words to read (default: 1)")
+    sub.add_parser("alive")
+    sub.add_parser("thaw")
+
     sp = sub.add_parser("screenshot")
     sp.add_argument("-o", "--out", default="screenshot.png")
     sp.add_argument("--surface", choices=sorted(SURFACES), default="lcd")
@@ -681,6 +853,16 @@ def main(argv=None):
         print("created", new_app(a.name))
     elif a.cmd == "install-app":
         install_app(a.uf2, a.device, a.timeout, a.port)
+    elif a.cmd == "run-app":
+        return run_app(a.name, reset=not a.no_reset, timeout=a.timeout)
+    elif a.cmd == "list-apps":
+        return list_apps()
+    elif a.cmd == "peek":
+        return run_peek(int(a.addr, 0), a.count)
+    elif a.cmd == "alive":
+        return run_alive()
+    elif a.cmd == "thaw":
+        return run_thaw()
     elif a.cmd == "screenshot":
         crop = tuple(int(v) for v in a.crop.split(",")) if a.crop else None
         if crop is not None and len(crop) != 4:

--- a/tools/fw.py
+++ b/tools/fw.py
@@ -7,7 +7,7 @@ Commands:
   fw flash [app]     program the app over the cmsis-dap debug probe via OpenOCD
   fw rtt             stream SEGGER RTT diagnostics
   fw test            build+run host unit tests (CTest, no hardware)
-  fw new-app <name>  scaffold apps/<name> from apps/template
+  fw new-app <name>  scaffold apps/<name> (--window FLASH|SRAM|PSRAM)
   fw install-app UF2 copy an app to the device SD card's /apps directory
   fw run-app <name>  launch /apps/<name> on the display CPU and report the result
   fw list-apps       list the SD card's /apps directory
@@ -611,14 +611,30 @@ def test_command():
         ["ctest", "--test-dir", str(build_dir), "--output-on-failure"],
     ]
 
-def new_app(name, repo_root=REPO_ROOT):
+APP_WINDOWS = ("FLASH", "SRAM", "PSRAM")
+
+def new_app(name, window="FLASH", repo_root=REPO_ROOT):
+    """Scaffold apps/<name> from apps/template, targeting `window`.
+
+    The window is a single token in the generated CMakeLists because everything
+    that follows from it -- binary type, linker overrides, runtime-init
+    overrides, UF2 emission, and the build-time check that the artifact matches
+    -- lives in fw2_finalize_app(). Choosing SRAM or PSRAM here is the whole of
+    what an app has to do to be loadable from the SD card without touching the
+    stock display firmware."""
+    window = window.upper()
+    if window not in APP_WINDOWS:
+        raise ValueError(f"window must be one of {', '.join(APP_WINDOWS)}")
     src = pathlib.Path(repo_root) / "apps" / "template"
     dest = pathlib.Path(repo_root) / "apps" / name
     if dest.exists():
         raise FileExistsError(dest)
     shutil.copytree(src, dest)
     cml = dest / "CMakeLists.txt"
-    cml.write_text(cml.read_text().replace("template", name))
+    text = cml.read_text().replace("template", name)
+    text = text.replace(f"fw2_finalize_app({name} FLASH)",
+                        f"fw2_finalize_app({name} {window})")
+    cml.write_text(text)
     return dest
 
 def _run(cmds, do_print):
@@ -793,6 +809,11 @@ def main(argv=None):
                     help="capture for N seconds then exit (0 = until Ctrl+C)")
     sp = sub.add_parser("test"); sp.add_argument("--print", dest="show", action="store_true")
     sp = sub.add_parser("new-app"); sp.add_argument("name")
+    sp.add_argument("--window", default="FLASH", choices=["FLASH", "SRAM", "PSRAM",
+                                                          "flash", "sram", "psram"],
+                    help="where the app runs: FLASH replaces the stock display "
+                         "firmware and is programmed over SWD; SRAM and PSRAM are "
+                         "loadable from the SD card (default: FLASH)")
     sp = sub.add_parser("install-app")
     sp.add_argument("uf2", help="app UF2 to copy into /apps on the device SD card")
     sp.add_argument("--device", help="fwFinder device serial (required when multiple devices are connected)")
@@ -850,7 +871,7 @@ def main(argv=None):
             return run_rtt(a.seconds)
     elif a.cmd == "test":  _run(test_command(), a.show)
     elif a.cmd == "new-app":
-        print("created", new_app(a.name))
+        print("created", new_app(a.name, a.window))
     elif a.cmd == "install-app":
         install_app(a.uf2, a.device, a.timeout, a.port)
     elif a.cmd == "run-app":
@@ -873,7 +894,23 @@ def main(argv=None):
                   f"{crop[0] if crop else 0} {crop[1] if crop else 0} "
                   f"{crop[2] if crop else 0} {crop[3] if crop else 0} {a.scale}")
             return 0
-        w, h = agentio_capture(a.surface, crop, a.scale, a.out)
+        try:
+            w, h = agentio_capture(a.surface, crop, a.scale, a.out)
+        except RuntimeError as e:
+            if "measuring" in str(e):
+                print("screenshot refused: the app is inside a timed region.\n"
+                      "  A capture streams 307,200 bytes from the app's own main "
+                      "loop, which would\n  land between its measurements and skew "
+                      "the result -- so it is refused rather\n  than silently "
+                      "corrupting it (agentio_measure_begin).\n"
+                      "  Wait for the run to finish, or capture before starting it.",
+                      file=sys.stderr)
+                return 1
+            if "busy" in str(e):
+                print("screenshot refused: an injected press or TYPE is still "
+                      "pending. Retry shortly.", file=sys.stderr)
+                return 1
+            raise
         print(f"wrote {a.out} ({w}x{h})")
     elif a.cmd in ("press", "hold", "release"):
         try:

--- a/tools/fw_console.py
+++ b/tools/fw_console.py
@@ -1,0 +1,136 @@
+r"""OneWili console client for the FreeWili 2 MAIN CPU's app-USB CDC.
+
+Used by `fw run-app` / `fw console`. MAIN's console is the tty whose USB parent
+is 093c:2060 ("FW2 v04"); this finds it by walking /dev/ttyACM*. It is NOT
+2e8a:0009 -- that is a raw Pico SDK build, not stock firmware -- and the two
+CDCs on the debug probe (2e8a:000c) are UART bridges, not this console.
+
+No pyserial dependency: this drives the tty through termios directly, so it
+works on a bare checkout.
+
+Two things are needed and neither is discoverable:
+
+  - **Assert DTR.** The SDK's stdio_usb only transmits while tud_cdc_connected(),
+    which requires the host to raise DTR. A raw open leaves it low and the board
+    looks completely dead.
+  - **Send leaf paths, not navigation.** Menus do not answer: 'h' produces
+    nothing. '?' and full backslash paths with args do. A \x02 prefix returns
+    the menu to root first.
+
+Responses are frames: [<echoed path> <hexTimestampNs> <seq> <response>]
+
+Paths this module uses -- full set in libs/onewili/include/onewili.h:
+
+    ?             identify
+    h\x\k <n>     SDCard Host Select: 0 = MAIN, 1 = USB reader / PC
+    h\v\l         List Display Apps (the card's /apps directory)
+    h\v\x         Reset Display CPU (RUN pulse)
+    a\r <file>    Run App -- destination inferred from the IMAGE, not the name:
+                  an SRAM-targeted UF2 is staged into RAM, a PSRAM-window one
+                  through FW2PsramStub, anything else is written to flash
+"""
+import fcntl
+import glob
+import os
+import re
+import select
+import struct
+import subprocess
+import termios
+import time
+
+RESET_QUIET = b"\x02"
+FRAME_RE = re.compile(
+    r"\[([a-zA-Z0-9?](?:\\[a-zA-Z0-9])*)\s+([0-9a-fA-F]+)\s+(\d+)\s*(.*?)\]", re.S)
+
+TIOCMBIS = 0x5416
+TIOCM_DTR = 0x002
+TIOCM_RTS = 0x004
+
+CONSOLE_VID, CONSOLE_PID = "093c", "2060"
+
+NO_CONSOLE_HELP = (
+    f"no {CONSOLE_VID}:{CONSOLE_PID} console found.\n"
+    "  Is MAIN running, and is every debugger detached? A debug-halted core "
+    "stops TIMER0\n  via DBGPAUSE, and MAIN then wedges in a busy-wait before "
+    "its USB init.\n"
+    "  Override the port with OW_TTY=/dev/ttyACMx if autodetection is wrong.")
+
+
+def find_console():
+    """The tty whose USB parent is the MAIN CPU's app CDC."""
+    for dev in sorted(glob.glob("/dev/ttyACM*")):
+        try:
+            out = subprocess.run(["udevadm", "info", "-q", "property", "-n", dev],
+                                 capture_output=True, text=True, timeout=5).stdout
+        except Exception:
+            continue
+        if (f"ID_VENDOR_ID={CONSOLE_VID}" in out
+                and f"ID_MODEL_ID={CONSOLE_PID}" in out):
+            return dev
+    return None
+
+
+def open_port(dev, baud=115200):
+    fd = os.open(dev, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+    speed = getattr(termios, "B%d" % baud)
+    cc = list(termios.tcgetattr(fd)[6])
+    cc[termios.VMIN] = 0
+    cc[termios.VTIME] = 0
+    termios.tcsetattr(fd, termios.TCSANOW,
+                      [0, 0, termios.CS8 | termios.CREAD | termios.CLOCAL, 0,
+                       speed, speed, cc])
+    termios.tcflush(fd, termios.TCIOFLUSH)
+    fcntl.ioctl(fd, TIOCMBIS, struct.pack("I", TIOCM_DTR | TIOCM_RTS))
+    time.sleep(0.05)
+    return fd
+
+
+def read_for(fd, secs, idle=None):
+    """Read until `secs` elapse, or until `idle` seconds pass with no new data."""
+    out = b""
+    deadline = time.time() + secs
+    last = time.time()
+    while time.time() < deadline:
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if r:
+            try:
+                chunk = os.read(fd, 65536)
+            except BlockingIOError:
+                chunk = b""
+            if chunk:
+                out += chunk
+                last = time.time()
+        elif idle is not None and out and time.time() - last > idle:
+            break
+    return out
+
+
+def call(fd, cmd, wait=15.0, idle=4.0):
+    """Send one leaf path and collect the frames it produces."""
+    os.write(fd, RESET_QUIET + cmd.encode("ascii") + b"\n")
+    raw = read_for(fd, wait, idle=idle).decode("latin1")
+    return raw, FRAME_RE.findall(raw)
+
+
+class Console:
+    """Context manager around the MAIN console."""
+
+    def __init__(self, dev=None):
+        self.dev = dev or os.environ.get("OW_TTY") or find_console()
+        if not self.dev:
+            raise SystemExit(NO_CONSOLE_HELP)
+        self.fd = None
+
+    def __enter__(self):
+        self.fd = open_port(self.dev)
+        read_for(self.fd, 0.4)          # drain whatever was already buffered
+        return self
+
+    def __exit__(self, *exc):
+        if self.fd is not None:
+            os.close(self.fd)
+        return False
+
+    def call(self, cmd, wait=15.0, idle=4.0):
+        return call(self.fd, cmd, wait=wait, idle=idle)

--- a/tools/openocd/freewili2.cfg
+++ b/tools/openocd/freewili2.cfg
@@ -8,3 +8,43 @@ source [find interface/cmsis-dap.cfg]
 cmsis-dap usb interface 0
 adapter speed 5000
 source [find target/rp2350.cfg]
+
+# Attach to a RUNNING target without disturbing it.
+#
+# rp2350.cfg overrides `proc init_reset` to perform a full reset, and OpenOCD's
+# `init` calls it. For a flashed app that is invisible -- the core simply
+# restarts from flash, which is why `fw rtt` has always looked fine against the
+# apps/ tree. For a RAM or PSRAM app it is FATAL: the reset erases the staged
+# image, so `fw rtt` / `fw screenshot` destroy the app they were asked to
+# observe and then report "rtt: No control block found".
+#
+# That misreads as "your app crashed", and it has cost a downstream project two
+# sessions: it concluded PSRAM launches were broken, and converted its app to a
+# flash build to work around a bug that did not exist -- overwriting the stock
+# display firmware in the process. `reset_config none` alone is NOT enough,
+# because the reset comes from init_reset.
+#
+# `fw flash` still resets deliberately: it passes `program ... verify reset`,
+# which drives the reset itself rather than relying on init.
+proc init_reset { mode } { }
+reset_config none separate
+
+# Never examine core 1.
+#
+# The display apps this BSP builds are single-core, so cm1 has never been
+# started and sits at pc 0x00000000. OpenOCD's examination leaves it debug-
+# halted, and TIMER0's DBGPAUSE (0x400b002c, reset value 0x7) pauses the timer
+# whenever EITHER core is halted. `resume` only resumes the current target, and
+# the SMP resume of cm1 fails ("resume of a SMP target failed"), so cm1 stays
+# halted and TIMER0 stays paused -- after OpenOCD has exited.
+#
+# The app does not appear dead, which is what makes it expensive: time_us_64()
+# stops, so the LVGL tick stops, so every LVGL timer stops -- no redraws, no
+# input polling, `fw touch` does nothing. But anything driven straight off the
+# main loop (agentio) still answers OK. It reads exactly like a hung UI.
+#
+# Deferring the examine keeps cm1 out of debug state entirely. cm0 is
+# unaffected: `fw flash`, `fw rtt` and memory reads all target it.
+targets rp2350.cm1
+rp2350.cm1 configure -defer-examine
+targets rp2350.cm0

--- a/tools/tests/test_uf2check.py
+++ b/tools/tests/test_uf2check.py
@@ -1,0 +1,40 @@
+import pathlib
+import struct
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import uf2check
+
+
+def uf2_block(address, payload, *, declared_size=None, block_no=0, block_count=1):
+    data = bytearray(uf2check.BLOCK)
+    size = len(payload) if declared_size is None else declared_size
+    struct.pack_into(
+        "<8I", data, 0,
+        uf2check.UF2_MAGIC0, uf2check.UF2_MAGIC1, 0,
+        address, size, block_no, block_count, 0xE48BFF59,
+    )
+    data[32:32 + len(payload)] = payload
+    struct.pack_into("<I", data, uf2check.BLOCK - 4, uf2check.UF2_MAGIC_END)
+    return bytes(data)
+
+
+def test_rejects_payload_larger_than_uf2_capacity():
+    block = uf2_block(0x11000000, b"", declared_size=477)
+
+    with pytest.raises(SystemExit, match="oversized payload 477"):
+        list(uf2check.parse_blocks(block))
+
+
+def test_rejects_payload_crossing_window_end(tmp_path):
+    vector = struct.pack("<II", 0x20082000, 0x11000001) + bytes(248)
+    image = (
+        uf2_block(0x11000000, vector, block_no=0, block_count=2)
+        + uf2_block(0x117FFF80, bytes(256), block_no=1, block_count=2)
+    )
+    path = tmp_path / "crossing.uf2"
+    path.write_bytes(image)
+
+    assert uf2check.main([str(path), "--window", "psram", "--quiet"]) == 1

--- a/tools/uf2check.py
+++ b/tools/uf2check.py
@@ -67,7 +67,9 @@ def parse_blocks(data):
         magic_end, = struct.unpack_from("<I", data, off + BLOCK - 4)
         if magic0 != UF2_MAGIC0 or magic1 != UF2_MAGIC1 or magic_end != UF2_MAGIC_END:
             raise SystemExit(f"uf2check: block {i} has bad UF2 magic")
-        payload = data[off + 32: off + 32 + min(size, 476)]
+        if size > 476:
+            raise SystemExit(f"uf2check: block {i} declares oversized payload {size}")
+        payload = data[off + 32: off + 32 + size]
         yield i, flags, addr, payload
 
 
@@ -92,7 +94,8 @@ def main(argv=None):
 
     # 1. Every payload block inside the declared window. This is the check that
     #    keeps an app off the stock firmware's address.
-    stray = [(i, addr) for i, _f, addr, _pl in payload if not (lo <= addr < hi)]
+    stray = [(i, addr) for i, _f, addr, pl in payload
+             if not (lo <= addr and addr + len(pl) <= hi)]
     if stray:
         i, addr = stray[0]
         where = next((n for n, (wlo, whi) in WINDOWS.items() if wlo <= addr < whi),

--- a/tools/uf2check.py
+++ b/tools/uf2check.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Validate a FreeWili 2 display app UF2 against the window it claims to target.
+
+    tools/uf2check.py <app.uf2> --window {flash,sram,psram}
+
+Exits non-zero, with the offending block named, when the image would not do what
+the build says it does. `fw2_finalize_app()` runs this on every app at build
+time, so an app cannot reach an SD card in a state the loader will mishandle.
+
+This exists because these were prose rules that every consumer project had to
+read, remember, and apply by hand -- and at least one did not:
+
+  - AGENTS.md: "/apps/ is a non-destructive DISPLAY launch surface. App UF2s may
+    target only SRAM or PSRAM, never QSPI flash ... a write at flash base
+    replaces the stock DISPLAY firmware, not the loader."
+  - AGENTS.md invariant 12: "Keep the vector table first in PSRAM, with its
+    initial stack in SRAM ... Verify symbol addresses plus every UF2 target
+    block."
+
+A downstream project shipped a flash-targeted UF2 to `/apps/` and overwrote
+FW2Display, having reasoned its way past the first rule; `fw install-app`
+catches that, but only if you use it, and the card-swap recipe most projects
+actually use does not. A build-time check cannot be routed around.
+
+The windows are the same ones `fw.py` enforces at install time:
+
+    flash  0x10000000..0x11000000   stock DISPLAY firmware lives here
+    psram  0x11000000..0x11800000   8 MB APS6404L, staged by FW2PsramStub
+    sram   0x20000000..0x20070000   fused bootloader stages here directly
+                                    (it runs from 0x20070000, hence the top)
+"""
+import argparse
+import struct
+import sys
+
+UF2_MAGIC0 = 0x0A324655
+UF2_MAGIC1 = 0x9E5D5157
+UF2_MAGIC_END = 0x0AB16F30
+BLOCK = 512
+
+# UF2 flags. A "no flash" block carries no payload for the target and must not
+# be range-checked -- picotool emits one at the top of flash on RP2350 as an
+# erratum workaround, and it is not part of the image.
+FLAG_NOT_MAIN_FLASH = 0x00000001
+
+WINDOWS = {
+    "flash": (0x10000000, 0x11000000),
+    "psram": (0x11000000, 0x11800000),
+    "sram":  (0x20000000, 0x20070000),
+}
+
+# The initial stack pointer must land in SRAM for every binary type: a PSRAM app
+# executes from the window but must not put its stack there, and the SDK's own
+# layouts always park SP at the top of SRAM.
+SRAM_LO, SRAM_HI = 0x20000000, 0x20082001  # inclusive top: SP is usually 0x20082000
+
+
+def parse_blocks(data):
+    """Yield (index, flags, addr, payload) for each well-formed UF2 block."""
+    if len(data) % BLOCK:
+        raise SystemExit(f"uf2check: not a UF2 -- {len(data)} bytes is not a "
+                         f"multiple of {BLOCK}")
+    for i in range(len(data) // BLOCK):
+        off = i * BLOCK
+        magic0, magic1, flags, addr, size, _blk, _n, _fam = struct.unpack_from(
+            "<8I", data, off)
+        magic_end, = struct.unpack_from("<I", data, off + BLOCK - 4)
+        if magic0 != UF2_MAGIC0 or magic1 != UF2_MAGIC1 or magic_end != UF2_MAGIC_END:
+            raise SystemExit(f"uf2check: block {i} has bad UF2 magic")
+        payload = data[off + 32: off + 32 + min(size, 476)]
+        yield i, flags, addr, payload
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("uf2")
+    ap.add_argument("--window", required=True, choices=sorted(WINDOWS))
+    ap.add_argument("--quiet", action="store_true")
+    a = ap.parse_args(argv)
+
+    lo, hi = WINDOWS[a.window]
+    with open(a.uf2, "rb") as fh:
+        data = fh.read()
+
+    blocks = [(i, f, addr, pl) for i, f, addr, pl in parse_blocks(data)]
+    payload = [b for b in blocks if not (b[1] & FLAG_NOT_MAIN_FLASH)]
+    if not payload:
+        raise SystemExit("uf2check: no payload blocks")
+
+    errors = []
+
+    # 1. Every payload block inside the declared window. This is the check that
+    #    keeps an app off the stock firmware's address.
+    stray = [(i, addr) for i, _f, addr, _pl in payload if not (lo <= addr < hi)]
+    if stray:
+        i, addr = stray[0]
+        where = next((n for n, (wlo, whi) in WINDOWS.items() if wlo <= addr < whi),
+                     "outside every known window")
+        errors.append(
+            f"{len(stray)} of {len(payload)} blocks fall outside the {a.window} "
+            f"window {lo:#010x}..{hi:#010x};\n"
+            f"    first is block {i} at {addr:#010x}, which is in {where}.\n"
+            f"    The build says {a.window} but the image targets somewhere else -- "
+            f"fix the binary type or the declared window, not this check.")
+        if where == "flash":
+            errors.append(
+                "flash is where the stock DISPLAY firmware lives. Installing this "
+                "to /apps/ would\n    REPLACE FW2Display. See AGENTS.md, "
+                "'/apps/ is a non-destructive DISPLAY launch surface'.")
+
+    # 2. Vector table first, at the window base. The loader jumps via word 0/1 of
+    #    the base block, so an image whose first bytes are not a vector table
+    #    launches into nothing. (AGENTS.md invariant 12.)
+    base = min(addr for _i, _f, addr, _pl in payload)
+    if base != lo:
+        errors.append(
+            f"image starts at {base:#010x}, not the {a.window} base {lo:#010x}.\n"
+            f"    The loader classifies on the first block and jumps via the "
+            f"vector table at the base.")
+    else:
+        first = next(pl for _i, _f, addr, pl in payload if addr == base)
+        if len(first) < 8:
+            errors.append("base block is too short to hold a vector table")
+        else:
+            sp, pc = struct.unpack_from("<II", first, 0)
+            if not (SRAM_LO <= sp <= SRAM_HI):
+                errors.append(
+                    f"initial SP is {sp:#010x}, which is not in SRAM "
+                    f"({SRAM_LO:#010x}..{SRAM_HI:#010x}).\n"
+                    f"    Invariant 12: the vector table goes first in the window, "
+                    f"its stack in SRAM.")
+            if not (lo <= (pc & ~1) < hi):
+                errors.append(
+                    f"reset vector is {pc:#010x}, which is not in the {a.window} "
+                    f"window.")
+            elif not (pc & 1):
+                errors.append(
+                    f"reset vector {pc:#010x} has the thumb bit clear; the core "
+                    f"will fault on entry.")
+
+    if errors:
+        sys.stderr.write(f"\nuf2check: {a.uf2} FAILED as a '{a.window}' app\n")
+        for e in errors:
+            sys.stderr.write(f"  - {e}\n")
+        sys.stderr.write("\n")
+        return 1
+
+    if not a.quiet:
+        top = max(addr for _i, _f, addr, _pl in payload)
+        extra = len(blocks) - len(payload)
+        note = f" (+{extra} non-payload)" if extra else ""
+        print(f"uf2check: {a.window} OK -- {len(payload)} blocks{note}, "
+              f"{base:#010x}..{top:#010x}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> **Stacked on #19** (`fix/agentio-shadow-fixed-psram-address`) so the diff here is just this work's 3 commits. Retarget to `master` once #19 lands.

## Why

Consumer projects had to read, remember and hand-apply a set of rules about how a display app must be built and observed. That does not hold up in practice.

Two concrete failures drove this PR, both in projects consuming wilibsp:

- One reasoned its way past *"/apps/ may never target flash"* and **overwrote the stock display firmware (FW2Display)**.
- One spent two sessions concluding PSRAM launches were broken. They were not — **OpenOCD's attach was erasing the app it was asked to observe**, which is behaviour AGENTS.md already documented. That project then converted its app to a flash build to work around a bug that did not exist, which is how the first failure happened.

Both rules were written down. Neither was enforced. **An invariant that can be enforced should not be prose** — prose does not survive being skimmed, and it rots against a pinned submodule when copied into a consumer's docs.

## What changes

### `fw2_finalize_app(<target> SRAM|PSRAM|FLASH)`

The consumer declares the window once; everything follows:

- **PSRAM** — linker overrides moving the XIP window to `0x11000000`, `PICO_RUNTIME_SKIP_INIT_PSRAM`, the `runtime_init_early_resets` override sparing the bank-0 pad that carries XIP CS1 (GPIO47), and UF2 emission via `bin2uf2` because picotool rejects the window.
- **SRAM / FLASH** — the matching binary type and ordinary picotool outputs. FLASH warns at configure time that it replaces FW2Display and must not reach `/apps/`.

Every app is then verified against the window it claims, **on every build**, by `tools/uf2check.py`: every payload block inside the declared window, the image based at that window, a vector table first with its stack in SRAM and a thumb reset vector in range. That mechanises invariant 12's *"verify symbol addresses plus every UF2 target block"*, and unlike `fw install-app` it cannot be routed around by the card-swap recipe most projects actually use.

`PICO_BOARD != freewili2` is now a configure-time error rather than a silent revert to the RP2350A pin count.

### OpenOCD no longer disturbs the target

- `proc init_reset {}` + `reset_config none separate` — attaching no longer erases a RAM/PSRAM app.
- `rp2350.cm1 configure -defer-examine` — display apps are single-core, so cm1 sits at `pc 0` and OpenOCD's examine left it debug-halted. TIMER0's `DBGPAUSE` then paused the timer whenever either core was halted, and cm1 **cannot be resumed** (`resume of a SMP target failed`), so the pause outlived the OpenOCD process. `time_us_64()` stops → the LVGL tick stops → every LVGL timer stops. No redraws, no input polling, while anything driven off the main loop keeps answering. It presents as a hung UI.

### New commands

| | |
|---|---|
| `fw run-app <name>` | reset the display, launch `/apps/<name>`, wait for the **deferred** `[d]` frame rather than the immediate dispatch ack. Both steps are required and neither is discoverable. Non-zero exit with likely causes on failure. |
| `fw list-apps` | tell a failed launch apart from a missing file |
| `fw peek <addr>` | read memory from a running target — `init` + `read_memory`, never `halt` |
| `fw alive` | does TIMER0 advance? Liveness that does not perturb what it measures |
| `fw thaw` | rescue a board already frozen by an older config |
| `fw new-app --window` | scaffold FLASH/SRAM/PSRAM so the PSRAM recipe is never hand-rolled |

### `docs/consuming.md`

AGENTS.md is 450 lines and ~60 % is internal to editing wilibsp, so consumers skim it — which is how invariant 12 was missed by a project that quoted invariants 1 and 8 from the same file. Now that the enforceable rules ship as build checks, what a consumer needs is short. Both AGENTS.md and CLAUDE.md point at it and say plainly **not** to copy rules into a parent project's docs.

### `agentio_measure_begin()` / `_end()`

agentio is not a free observer: a capture RLE-encodes and streams 307,200 bytes from the app's own main loop. Inside a timed region that cost lands *between* the app's measurements, so its microsecond accounting misses it while wall-clock throughput collapses — a downstream benchmark published figures **5x and 15x low** this way and wrote it up as a hardware finding. A mid-run capture now fails with `ERR measuring`, and `fw screenshot` explains why. Injection stays allowed; it is cheap and usually starts the measured work.

## Verification (FW2 v04, on hardware)

- board guard fires on `-DPICO_BOARD=pico`; FLASH warns
- `uf2check` accepts the PSRAM build, rejects a flash-window image with the FW2Display message, rejects an SRAM image declared PSRAM
- a consumer app converted to `fw2_finalize_app(PSRAM)` builds byte-comparable to its hand-rolled config and boots: `runtime_init_early_resets` at `0x20000110` (SRAM), vectors `20082000/1100015b`, boot marker reaching its final value
- cm1 no longer examined; `halt`+`resume` leaves TIMER0 running
- `fw run-app` launches both a bare control app and a full LVGL app; a missing file exits 1
- capture succeeds idle → refused mid-run → succeeds after

## Depends on

`libs/onewili` submodule bump → freewili/onewili#4 (the `sdfs_hwrite` overrun fix). Merge that first, and note it must land with the corresponding firmware MR or the next sync reverts it.