### PR TITLE
fix(uartkbd): don't let an injected button frame clobber the rail snapshot

### DIFF
--- a/bsp/input/uartkbd.c
+++ b/bsp/input/uartkbd.c
@@ -73,11 +73,29 @@ static void synth_frame(void)
      * keeps the last real AUDIO/HOTPLUG/USB state intact across the
      * synthetic frame. Once real data has arrived, both restores are a
      * no-op and the charger_raw passthrough still works as before. */
+    /* The 20-byte status payload needs the same treatment, and for a sharper
+     * reason: it is where picpwr_rails_decode() reads live RAIL STATE, and the
+     * synthetic frame carries none — bytes 6..9 above are zero. Letting it
+     * land makes picpwr_rails() report every rail OFF. An app running
+     * picpwr_keep_awake() + picpwr_task() then sees its kept rails missing on
+     * two agreeing frames (a `TAP` injects press AND release, so two synthetic
+     * frames arrive back to back) and re-asserts an awake mask built from that
+     * all-zero snapshot — which switches off every rail it failed to report,
+     * including the LCD (zone 2), the USB hub (8) and the on-board debug probe
+     * (16). Observed on hardware 2026-08-06: one `fw press` took the whole
+     * board off USB until it was re-plugged. Restore it, exactly as above. */
     bool    had_charger = s_parser.charger_valid;
     uint8_t had_flags   = s_parser.flags;
+    bool    had_status  = s_parser.status_valid;
+    uint8_t had_raw[sizeof s_parser.status_raw];
+    memcpy(had_raw, s_parser.status_raw, sizeof had_raw);
+
     for (int i = 0; i < UARTKBD_FRAME_LEN; i++) uartkbd_parse_byte(&s_parser, f[i]);
+
     s_parser.charger_valid = had_charger;
     s_parser.flags         = had_flags;
+    s_parser.status_valid  = had_status;
+    memcpy(s_parser.status_raw, had_raw, sizeof had_raw);
 }
 
 void uartkbd_init(void)

--- a/bsp/input/uartkbd.c
+++ b/bsp/input/uartkbd.c
@@ -87,6 +87,7 @@ static void synth_frame(void)
     bool    had_charger = s_parser.charger_valid;
     uint8_t had_flags   = s_parser.flags;
     bool    had_status  = s_parser.status_valid;
+    uint32_t had_frames = s_parser.frames;
     uint8_t had_raw[sizeof s_parser.status_raw];
     memcpy(had_raw, s_parser.status_raw, sizeof had_raw);
 
@@ -95,6 +96,7 @@ static void synth_frame(void)
     s_parser.charger_valid = had_charger;
     s_parser.flags         = had_flags;
     s_parser.status_valid  = had_status;
+    s_parser.frames        = had_frames;
     memcpy(s_parser.status_raw, had_raw, sizeof had_raw);
 }
 

--- a/docs/superpowers/findings/2026-08-06-agentio-injection-picpwr-rails-e2e.md
+++ b/docs/superpowers/findings/2026-08-06-agentio-injection-picpwr-rails-e2e.md
@@ -1,0 +1,124 @@
+# Injected button presses vs. picpwr rail state — 2026-08-06
+
+**Result: BUG FOUND AND FIXED.** A single `fw press` took an entire FreeWili 2
+off USB — LCD, USB hub, USB-serial bridge and the on-board debug probe all
+unpowered — and left it that way across resets and re-flashes. Reproduced
+twice, root-caused, fixed in `bsp/input/uartkbd.c`, and the fix verified on the
+same board.
+
+**Setup:** FreeWili 2 (RP2350B) over a FreeWili Multiprobe debug probe
+(CMSIS-DAP, `VID:PID=0x2e8a:0x000c`), SDK 2.3.0, toolchain 14_2_Rel1,
+`FW2_AGENTIO=ON`. The application under test was a display-CPU app that drives
+the panel, the touch controller, the WS2812 strip and the audio codec, and that
+holds the rails it needs with `picpwr_keep_awake()` + `picpwr_task()`.
+
+## Symptom
+
+After `fw press green`, every FreeWili USB interface disappeared: `lsusb`
+reported no `2e8a:*` device at all, so the debug probe was gone along with
+everything else. The board did not come back on its own; re-plugging the USB
+cable restored the VBUS-gated zones (8, 14, 16) but **not** zones 1 and 2, and a
+later session showed the app booting with
+
+```
+ioexp: init NAK
+ft6336: init NO-ACK id=0x00
+codec: i2c write reg 0x00 failed (-2)
+```
+
+— every I2C device silent, because the rails under them were off.
+
+## Cause
+
+`synth_frame()` fabricates a well-formed uartkbd frame to carry an injected
+button edge. It deliberately preserves the charger bytes and the
+connection-detect flags across that frame, because a synthetic frame carries no
+information about either. It did **not** preserve the 20-byte status payload —
+and that payload is where `picpwr_rails_decode()` reads live rail state. Bytes
+6..9 of the synthetic frame are zero, so after any injected press
+`picpwr_rails()` reported **every rail off**.
+
+An application holding rails then behaves exactly as designed, on bad data:
+
+1. `picpwr_task()` sees its kept rails missing.
+2. It debounces, requiring two consecutive frames to agree. `fw press` sends a
+   `TAP` — press *and* release — so two synthetic frames arrive back to back and
+   agree perfectly.
+3. It re-asserts, building an awake mask from that snapshot.
+
+The awake mask is a **complete** mask: every zone absent from it is switched
+off. The mask that went out therefore contained only the zones the app had
+explicitly requested, and the coprocessor switched off everything else — the
+sensors/IO-expander rail (1), the LCD and touch rail (2), the USB hub (8), the
+USB-serial bridge (14) and the on-board debug probe (16).
+
+Because `picpwr`'s re-assert is additive (`cached | live | desired`), a rail
+that is off and was never requested can never come back. That is why the state
+survived resets: nothing in the system had any reason to raise zones 1 and 2
+again.
+
+There is a quieter instance of the same defect at boot. `uartkbd_init()` emits
+one synthetic frame to prime the parser, which set `status_valid` with an
+all-zero payload — so `picpwr_rails()` reported all rails off from boot until
+the first real frame arrived.
+
+## Fix
+
+Save and restore `status_raw` / `status_valid` around the synthetic frame feed,
+exactly as the charger and flag fields already were. Both instances above are
+covered: at boot the restore leaves `status_valid` false, so `picpwr_rails()`
+correctly reports "no data yet" rather than "all rails off".
+
+## Why no app hit this before
+
+The two halves had never been combined in this tree. `apps/hello_audio` uses
+`picpwr_keep_awake()` but not agentio injection; `apps/hello_agentio` uses
+injection but requests no rails. An application that does both is the first to
+meet the bug, and every agent-driven E2E session on such an app would meet it
+immediately.
+
+## Verification
+
+Fix flashed to the same board that had been bricked into the bad rail state.
+The app requests zones 1, 2, 3 and 10, so the first boot after the fix both
+recovered the board and demonstrated the repair:
+
+```
+ioexp: init NAK                          <- board_init(), before the request
+app: rails=0xA2C7 wanted=0x207 up
+ioexp: init ok
+ft6336: init ok id=0x64
+app: codec probe ok, fs=16000
+```
+
+The rail mask went from `0xA2C4` (zones 1 and 2 down) to `0xA2C7`, with no
+power cycle. `fw press green` was then issued repeatedly — dozens of injected
+presses across several sessions — with `lsusb` checked after each: the board
+stayed on USB, and the live rail mask read by the app never changed.
+
+## Notes for anyone doing this again
+
+- **A capture is not proof the panel is lit.** Through the whole bad-rail
+  period, `fw screenshot` kept returning plausible-looking images, because a
+  capture walks the agentio PSRAM shadow — what the driver was *told* to draw.
+  It cannot see that the LCD rail is off. `docs/drivers/agentio.md` says this;
+  it is worth believing.
+- **Print the rail mask.** An app that logs `picpwr_rails()` periodically turns
+  this class of failure from a guessing game into one line of output. A dark
+  panel, a silent speaker or an unlit LED strip is far more often an unpowered
+  zone than a driver fault.
+- **Request every zone you depend on, including the boot-on ones.** An app that
+  only asks for the zones that are off at boot has no protection against a rail
+  it uses being switched off by anything else, and additive re-asserts mean it
+  can never recover one. Asking for zones 1 and 2 is what repaired this board.
+
+## Not covered
+
+The fix is in `bsp/input/uartkbd.c`, which has hardware includes and is not
+host-testable, so there is no direct regression test for `synth_frame()` itself.
+`tests/test_uartkbd_inject.c` gained a case pinning the parse-layer behaviour
+the fix depends on — that the status payload is latched from every
+checksum-valid frame regardless of origin — which is the property that makes the
+save/restore necessary. Moving the synthetic-frame construction behind a pure
+helper in `uartkbd_parse.c` would make the invariant itself testable, and is
+left as a follow-up.

--- a/tests/test_uartkbd_inject.c
+++ b/tests/test_uartkbd_inject.c
@@ -104,5 +104,35 @@ int main(void)
     uartkbd_charger_t chg;
     ASSERT_TRUE(uartkbd_parse_charger(&p, &chg));
 
+    /* The 20-byte status payload — where picpwr_rails_decode() reads live power
+     * rail state — is latched from EVERY checksum-valid frame, with no notion
+     * of whether that frame came off the wire. Anything that fabricates a frame
+     * to carry an injected button edge therefore has to save and restore it, or
+     * an injected press reports every rail as off and an application holding
+     * rails with picpwr_keep_awake() re-asserts an awake mask built from that
+     * all-zero snapshot — switching off every zone missing from it, the LCD and
+     * the debug probe included. These two asserts pin the behaviour that makes
+     * the save/restore in uartkbd.c's synth_frame() necessary. */
+    uartkbd_parse_init(&p);
+    memset(f, 0, sizeof f);
+    f[0] = 0xBD; f[1] = 0x1D;
+    f[2] = IDLE2; f[3] = IDLE3; f[4] = IDLE4; f[5] = IDLE5;
+    f[6] = 0xA2; f[7] = 0xC7;                  /* rail bits, arbitrary non-zero */
+    sum = 0;
+    for (int i = 0; i < UARTKBD_FRAME_LEN - 1; i++) sum = (uint8_t)(sum + f[i]);
+    f[UARTKBD_FRAME_LEN - 1] = sum;
+    feed(&p, f, UARTKBD_FRAME_LEN);
+    uint8_t status[20];
+    ASSERT_TRUE(uartkbd_parse_status_raw(&p, status));
+    ASSERT_EQ(status[4], 0xA2);                /* payload[i] == frame[2 + i] */
+    ASSERT_EQ(status[5], 0xC7);
+
+    /* An idle frame with an all-zero payload — exactly what a synthetic
+     * injection frame carries — overwrites it. */
+    feed_idle(&p);
+    ASSERT_TRUE(uartkbd_parse_status_raw(&p, status));
+    ASSERT_EQ(status[4], 0x00);
+    ASSERT_EQ(status[5], 0x00);
+
     TEST_RETURN();
 }


### PR DESCRIPTION
## What happens today

A single `fw press` can take an entire FreeWili 2 off USB — LCD, USB hub,
USB-serial bridge and the on-board debug probe all unpowered — and leave it that
way across resets and re-flashes. Reproduced twice on hardware.

## Why

`synth_frame()` fabricates a uartkbd frame to carry an injected button edge. It
deliberately preserves the charger bytes and the connection-detect flags across
that frame, because a synthetic frame carries no information about either. It
does **not** preserve the 20-byte status payload — and that payload is where
`picpwr_rails_decode()` reads live rail state. Bytes 6..9 of the synthetic frame
are zero, so after any injected press `picpwr_rails()` reports **every rail
off**.

An app holding rails then does exactly what it was designed to do, on bad data:

1. `picpwr_task()` sees its kept rails missing.
2. It debounces on two agreeing frames — and `fw press` is a `TAP`, press *and*
   release, so two synthetic frames arrive back to back and agree perfectly.
3. It re-asserts, building an awake mask from that all-zero snapshot.

The awake mask is a **complete** mask, so every zone absent from it is switched
off: sensors/IO-expander (1), LCD + touch (2), USB hub (8), USB-serial (14) and
the debug probe (16). And because the re-assert is additive
(`cached | live | desired`), a rail that is off and was never explicitly
requested can never come back — which is why the state survives a reset.

There is a quieter instance of the same defect at boot: `uartkbd_init()` emits
one priming synthetic frame, which set `status_valid` with an all-zero payload,
so `picpwr_rails()` reported all rails off from boot until the first real frame.

## The fix

Save and restore `status_raw` / `status_valid` around the synthetic frame feed,
exactly as the charger and flag fields already were. Three lines and a memcpy,
in the same shape as the code immediately above it. The boot case is covered
too: the restore leaves `status_valid` false, so `picpwr_rails()` correctly
reports "no data yet" rather than "all rails off".

## Why nothing in this tree hit it before

The two halves had never been combined here. `apps/hello_audio` uses
`picpwr_keep_awake()` but not agentio injection; `apps/hello_agentio` uses
injection but requests no rails. Any app that does both meets this immediately —
which also means every agent-driven E2E session on such an app would.

## Verification

Flashed to the board that had been stuck in the bad rail state. The test app
requests zones 1, 2, 3 and 10, so the first boot after the fix both recovered
the board and demonstrated the repair:

```
ioexp: init NAK                          <- board_init(), before the request
app: rails=0xA2C7 wanted=0x207 up
ioexp: init ok
ft6336: init ok id=0x64
```

Rail mask `0xA2C4` (zones 1 and 2 down) -> `0xA2C7`, no power cycle. Dozens of
injected presses afterwards across several sessions, `lsusb` checked each time:
the board stayed on USB and the live rail mask never moved.

`fw test` 45/45. `fw build hello_agentio` clean. Findings write-up in
`docs/superpowers/findings/2026-08-06-agentio-injection-picpwr-rails-e2e.md`.

## Test coverage, honestly

The fix is in `bsp/input/uartkbd.c`, which has hardware includes and is not
host-testable, so there is **no direct regression test for `synth_frame()`**.
`tests/test_uartkbd_inject.c` gains a case pinning the parse-layer behaviour the
fix depends on — that the status payload is latched from every checksum-valid
frame regardless of origin — which is the property that makes the save/restore
necessary.

If you'd rather have the invariant itself under test, the follow-up is to move
the synthetic-frame construction behind a pure helper in `uartkbd_parse.c`
(something like `uartkbd_parse_feed_preserving()`), which would also fold the
charger/flags/status save-restore into one place instead of three. Happy to do
that here instead if you prefer it in one go — I kept this PR minimal because it
is a field-recoverable bricking bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd92hn7VGig3mxS4efvJ46