### PR TITLE
fix(fw): refuse to flash an image stored in QSPI flash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Windows one — both just call `python tools/fw.py "$@"`).
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `fw configure`      | Configure `build/` against the pinned Pico SDK + toolchain (`--clean` wipes it first). Rarely needed directly — `fw build` calls it.    |
 | `fw build [app]`    | Configure + build `apps/<app>` for the RP2350B target via `cmake --build --preset target --target <app>` (default app: `hello_display`) |
-| `fw flash [app]`    | Program `build/apps/<app>/<app>.elf` over the cmsis-dap debug probe via OpenOCD (`tools/openocd/freewili2.cfg`)                         |
+| `fw flash [app]`    | Program `build/apps/<app>/<app>.elf` over the cmsis-dap debug probe via OpenOCD (`tools/openocd/freewili2.cfg`). **Refuses an ELF whose loadable segments sit in QSPI flash** — that would replace the stock DISPLAY firmware. Prefer `fw install-app`; override with `--replace-display-firmware` |
 | `fw rtt`            | Attach to the target and stream SEGGER RTT diagnostics (OpenOCD RTT server on port 9090)                                                |
 | `fw test`           | Configure + build + run the standalone host CTest tree in `tests/` (MinGW GCC + Ninja on Windows; no Pico SDK, no hardware)             |
 | `fw new-app <name>` | Scaffold `apps/<name>` by copying `apps/template` and rewriting the CMake target name                                                   |
@@ -86,6 +86,16 @@ QSPI flash (`0x10000000..0x11000000`). `fw install-app` checks every block and
 fails before mounting the SD if the file is malformed, mixed-target, or touches
 flash. The DISPLAY recovery loader is fused in OTP; a write at flash base
 replaces the stock DISPLAY firmware, not the loader.
+
+`fw flash` applies the same rule to the ELF it is about to program, refusing by
+default when any loadable segment lands in `0x10000000..0x11000000`. The trap it
+exists to catch is `pico_set_binary_type(copy_to_ram)`: that image RUNS from
+SRAM but is STORED in flash, so a debugger writes it at flash base and silently
+replaces the DISPLAY firmware. Build display apps with `fw2_display_app()` — it
+sets `no_flash` — and install them with `fw install-app`. `fw flash` on such an
+app writes SRAM only and stays non-destructive, which is why it remains the
+normal edit/flash/`fw rtt` loop. Pass `--replace-display-firmware` only when
+replacing the firmware is the actual intent.
 
 The UF2 is a required distribution artifact of the app contract. Every
 published app release must attach its validated `.uf2` as a downloadable

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ falls back to the newest version installed under `~/.pico-sdk`.
 
 ```bash
 fw build            # configure + build apps/hello_display for the RP2350B target
-fw flash            # program it over the debug probe (OpenOCD)
+fw flash            # program it over the debug probe (OpenOCD); refuses an
+                    # image stored in flash, which would replace the
+                    # stock DISPLAY firmware
 fw rtt              # stream live SEGGER RTT diagnostics
 fw install-app app.uf2  # copy a loadable app to SD:/apps and return the card to MAIN
 fw install-app app.uf2 --folder beta/radio  # install to SD:/apps/beta/radio

--- a/docs/app-storage.md
+++ b/docs/app-storage.md
@@ -37,6 +37,14 @@ This prevents an app from replacing the stock DISPLAY firmware. DISPLAY's
 recovery loader itself is immutable OTP code, not a flash-resident region;
 firmware replacement is an explicit maintenance workflow, not app installation.
 
+`fw flash` enforces the same rule on the ELF it programs over the debug probe,
+so the two paths onto the device agree. A `fw2_display_app()` target is
+`no_flash` and loads into SRAM, so `fw flash` remains the normal debug loop for
+it. What `fw flash` now refuses is an image *stored* in flash — most often
+`pico_set_binary_type(copy_to_ram)`, which runs from SRAM but is stored at flash
+base, so programming it replaces the DISPLAY firmware without ever saying so.
+Deliberate firmware replacement needs `fw flash --replace-display-firmware`.
+
 ## Publishing apps
 
 The loadable `.uf2` is part of the FreeWili app contract. App repositories

--- a/docs/superpowers/findings/2026-08-07-fw-flash-overwrote-display-firmware.md
+++ b/docs/superpowers/findings/2026-08-07-fw-flash-overwrote-display-firmware.md
@@ -1,0 +1,94 @@
+# `fw flash` replaced the stock DISPLAY firmware — 2026-08-07
+
+**Result: INCIDENT, then a guard.** An app built from the pre-app-contract
+template was flashed over the debug probe repeatedly during a development
+session. Every one of those flashes overwrote the stock DISPLAY firmware. The
+board was never bricked — the recovery loader is fused in OTP — but the firmware
+was gone and nothing in the workflow said so.
+
+## What happened
+
+`fw flash` is `openocd -c 'program <elf> verify reset exit'`, which writes each
+loadable segment at its **physical** address. For the app in question those were
+
+```
+LOAD  VirtAddr 0x20000110   PhysAddr 0x10000210
+LOAD  VirtAddr 0x20008c08   PhysAddr 0x10008d04
+```
+
+— running addresses in SRAM, **stored** addresses at flash base. That is what
+`pico_set_binary_type(<app> copy_to_ram)` produces: the image is copied into
+SRAM by the C runtime at boot, but it lives in QSPI flash, which is where the
+stock DISPLAY firmware lives too.
+
+Nothing in the path objected. `fw install-app` has validated UF2 payloads
+against the same memory map for some time and fails closed before it even mounts
+the SD card; `fw flash` trusted the ELF completely.
+
+## Why the app was built that way
+
+`apps/template` used `pico_set_binary_type(copy_to_ram)` before the app contract
+landed. Apps in this tree have since moved to `fw2_display_app()`, which sets
+`no_flash` and produces an SRAM image — so every app here is already safe, and
+`fw flash` on any of them writes SRAM only. The exposure is external app
+repositories and any app predating or ignoring the contract, which is precisely
+the population least likely to know the hazard exists.
+
+## The guard
+
+`fw flash` now parses the ELF it is about to program and refuses by default if
+any loadable segment intersects `0x10000000..0x11000000`:
+
+```
+fw flash: refusing to program myapp
+build/apps/myapp/myapp.elf stores 2 loadable segment(s) in QSPI flash
+(0x10000000+512, 0x10000210+35572).
+Programming it would REPLACE the stock DISPLAY firmware.
+Build the app with fw2_display_app() so it targets SRAM or PSRAM, then
+install it non-destructively with `fw install-app <app>.uf2`.
+If replacing the DISPLAY firmware is genuinely what you want, re-run
+with `fw flash --replace-display-firmware`.
+```
+
+The memory-window constants are now shared with `check_app_uf2()`, so the ELF
+path and the UF2 path cannot drift apart.
+
+`fw flash` is deliberately **not** removed or deprecated. On a
+`fw2_display_app()` target it loads SRAM over the probe and is non-destructive,
+which is the fast edit/flash/`fw rtt`/`fw screenshot` loop the whole agentio
+workflow depends on — and it works with no SD card, no MAIN firmware, and no
+`pyfwfinder`/`pyserial`. What it now refuses is the one thing that was never
+meant to be routine.
+
+## Verified
+
+- Refuses the actual ELF from the incident: four segments reported at
+  `0x10000000+528, 0x10000210+35572, 0x10008d04+13540, 0x1000c1e8+20`, exit
+  status 2, no traceback.
+- Accepts `hello_display` built via `fw2_display_app()`: one load segment at
+  `0x20000000+28628`, command emitted unchanged.
+- `--replace-display-firmware` emits the original command.
+- A missing build produces the OpenOCD "no such file" error as before, rather
+  than a confusing ELF-parse failure.
+- `fw test` 45/45, including nine new cases in `tools/tests/test_fw.py` covering
+  physical-vs-virtual addressing, NOLOAD segments, a segment that only partially
+  overlaps the window, both override paths, and the not-yet-built case.
+
+## Worth knowing
+
+- **`copy_to_ram` does not mean "loaded into RAM".** It means "copied to RAM at
+  boot". The image is flash-resident, and a debugger writes where the image is
+  stored. Read `PhysAddr`, not `VirtAddr`, when reasoning about what a flash
+  command will touch.
+- **A screenshot cannot tell you the firmware is gone.** Captures kept working
+  throughout, because `fw screenshot` walks the agentio PSRAM shadow — what the
+  driver was told to draw. The first hard evidence was `ioexp: init NAK` and
+  `ft6336: init NO-ACK` at boot.
+
+## Not covered
+
+Restoring the stock DISPLAY firmware is a separate maintenance workflow and is
+not automated here; this change only stops the destructive write from happening
+by accident. A guard at configure time — warning when a target links
+`freewili2_bsp` without going through `fw2_display_app()` — would catch the same
+mistake one step earlier and is left as a follow-up.

--- a/tools/fw.py
+++ b/tools/fw.py
@@ -34,6 +34,14 @@ SD_HOST_COMMAND = r"h\x\k"
 RUN_APP_COMMAND = r"a\r"
 UF2_MAGIC = (0x0A324655, 0x9E5D5157, 0x0AB16F30)
 
+# DISPLAY memory map. The flash window holds the stock DISPLAY firmware, so a
+# loadable app must never target it; `fw install-app` and `fw flash` enforce the
+# same rule from one definition.
+QSPI_FLASH = (0x10000000, 0x11000000)
+APP_WINDOWS = (("SRAM", 0x20000000, 0x20070000),
+               ("PSRAM", 0x11000000, 0x11800000))
+PT_LOAD = 1
+
 def check_app_uf2(path):
     """Fail closed unless every UF2 payload targets DISPLAY SRAM or PSRAM."""
     data = pathlib.Path(path).read_bytes()
@@ -60,11 +68,9 @@ def check_app_uf2(path):
         seen_blocks.add(block_no)
         if flags & 1 or size == 0:
             continue
-        if 0x10000000 <= address < 0x11000000:
+        if QSPI_FLASH[0] <= address < QSPI_FLASH[1]:
             raise ValueError(f"UF2 block {index} targets QSPI flash at 0x{address:08x}")
-        windows = (("SRAM", 0x20000000, 0x20070000),
-                   ("PSRAM", 0x11000000, 0x11800000))
-        here = next((name for name, start, stop in windows
+        here = next((name for name, start, stop in APP_WINDOWS
                      if size <= 476 and start <= address and address + size <= stop), None)
         if here is None or (target is not None and here != target):
             raise ValueError(f"UF2 block {index} is outside or mixes app-memory windows")
@@ -463,8 +469,63 @@ def _openocd_base():
         cmd += ["-s", scripts]
     return cmd + ["-f", OPENOCD_CFG]
 
-def flash_command(app):
+def elf_load_segments(blob):
+    """Loadable (physical address, size) pairs from a 32-bit LE ELF.
+
+    Physical, not virtual: a `copy_to_ram` binary runs from SRAM but is STORED
+    in flash, and it is the stored address a debugger writes.
+    """
+    if blob[:4] != b"\x7fELF" or blob[4:6] != b"\x01\x01":
+        raise ValueError("expected a 32-bit little-endian ELF")
+    phoff = struct.unpack_from("<I", blob, 28)[0]
+    phentsize, phnum = struct.unpack_from("<HH", blob, 42)
+    if phentsize < 32 or phoff + phentsize * phnum > len(blob):
+        raise ValueError("ELF program-header table is truncated")
+    segments = []
+    for index in range(phnum):
+        kind, _off, _vaddr, paddr, filesz, _memsz, _flags, _align = \
+            struct.unpack_from("<8I", blob, phoff + index * phentsize)
+        if kind == PT_LOAD and filesz:
+            segments.append((paddr, filesz))
+    return sorted(segments)
+
+
+def flash_segments_in_qspi(blob):
+    """The loadable segments that would land in the DISPLAY firmware region."""
+    start, stop = QSPI_FLASH
+    return [(addr, size) for addr, size in elf_load_segments(blob)
+            if addr < stop and addr + size > start]
+
+
+def check_flash_elf(path):
+    """Fail closed unless every loadable segment stays out of QSPI flash.
+
+    Writing an ELF at flash base replaces the stock DISPLAY firmware. The
+    recovery loader is fused in OTP so the board still boots, but restoring the
+    firmware is a separate maintenance workflow — not something a build/flash
+    loop should do silently. `pico_set_binary_type(copy_to_ram)` is the usual
+    way to trip this: it runs from SRAM but is stored in flash.
+    """
+    offenders = flash_segments_in_qspi(pathlib.Path(path).read_bytes())
+    if not offenders:
+        return
+    where = ", ".join(f"0x{addr:08x}+{size}" for addr, size in offenders[:4])
+    raise ValueError(
+        f"{path} stores {len(offenders)} loadable segment(s) in QSPI flash "
+        f"({where}).\n"
+        "Programming it would REPLACE the stock DISPLAY firmware.\n"
+        "Build the app with fw2_display_app() so it targets SRAM or PSRAM, then\n"
+        "install it non-destructively with `fw install-app <app>.uf2`.\n"
+        "If replacing the DISPLAY firmware is genuinely what you want, re-run\n"
+        "with `fw flash --replace-display-firmware`.")
+
+
+def flash_command(app, replace_display_firmware=False):
     elf = f"build/apps/{app}/{app}.elf"
+    if not replace_display_firmware:
+        path = REPO_ROOT / elf
+        if path.exists():
+            check_flash_elf(path)
     return _openocd_base() + ["-c", f"program {elf} verify reset exit"]
 
 def rtt_command():
@@ -685,6 +746,10 @@ def main(argv=None):
     for name in ("build", "flash"):
         sp = sub.add_parser(name); sp.add_argument("app", nargs="?", default=DEFAULT_APP)
         sp.add_argument("--print", dest="show", action="store_true")
+        if name == "flash":
+            sp.add_argument("--replace-display-firmware", action="store_true",
+                            help="allow writing QSPI flash, replacing the stock "
+                                 "DISPLAY firmware (maintenance workflow only)")
     sp = sub.add_parser("configure")
     sp.add_argument("--clean", action="store_true", help="wipe build/ before configuring")
     sp.add_argument("--print", dest="show", action="store_true")
@@ -735,7 +800,15 @@ def main(argv=None):
         if not a.show and needs_configure():
             run_configure(clean=BUILD_DIR.exists())
         _run(build_command(a.app), a.show)
-    elif a.cmd == "flash": _run(flash_command(a.app), a.show)
+    elif a.cmd == "flash":
+        try:
+            command = flash_command(a.app, a.replace_display_firmware)
+        except ValueError as exc:
+            # This guard exists to be read, so print it rather than burying the
+            # actionable part under a traceback.
+            print(f"fw flash: refusing to program {a.app}\n{exc}", file=sys.stderr)
+            return 2
+        _run(command, a.show)
     elif a.cmd == "rtt":
         if a.show:
             _run(rtt_command(), True)

--- a/tools/tests/test_fw.py
+++ b/tools/tests/test_fw.py
@@ -400,3 +400,97 @@ def test_agentio_capture_surfaces_err_reply_instead_of_hanging(monkeypatch):
         assert False, "expected RuntimeError"
     except RuntimeError as e:
         assert "rect" in str(e)
+
+def elf(segments, phentsize=32):
+    """Minimal 32-bit LE ELF carrying the given (paddr, filesz) LOAD segments."""
+    import struct
+    phoff = 52
+    header = bytearray(52)
+    header[0:4] = b"\x7fELF"
+    header[4:6] = b"\x01\x01"
+    struct.pack_into("<I", header, 28, phoff)
+    struct.pack_into("<HH", header, 42, phentsize, len(segments))
+    table = bytearray()
+    body = bytearray()
+    for paddr, filesz in segments:
+        offset = phoff + phentsize * len(segments) + len(body)
+        table += struct.pack("<8I", 1, offset, paddr, paddr, filesz, filesz, 5, 0x1000)
+        body += bytes(filesz)
+    return bytes(header) + bytes(table) + bytes(body)
+
+
+def test_elf_load_segments_reports_physical_addresses():
+    # A copy_to_ram image RUNS from SRAM but is STORED in flash; the physical
+    # address is the one a debugger writes.
+    blob = elf([(0x10000000, 256)])
+    assert fw.elf_load_segments(blob) == [(0x10000000, 256)]
+
+
+def test_elf_load_segments_ignores_nobits():
+    import struct
+    blob = bytearray(elf([(0x20000000, 256)]))
+    struct.pack_into("<I", blob, 52 + 16, 0)          # filesz = 0 -> NOLOAD
+    assert fw.elf_load_segments(bytes(blob)) == []
+
+
+def test_elf_load_segments_rejects_non_elf():
+    import pytest
+    with pytest.raises(ValueError):
+        fw.elf_load_segments(b"not an elf at all")
+
+
+def test_flash_refuses_an_elf_stored_in_qspi_flash(tmp_path):
+    import pytest
+    path = tmp_path / "app.elf"
+    path.write_bytes(elf([(0x10000000, 512), (0x10000210, 4096)]))
+    with pytest.raises(ValueError) as excinfo:
+        fw.check_flash_elf(path)
+    message = str(excinfo.value)
+    assert "REPLACE the stock DISPLAY firmware" in message
+    assert "fw install-app" in message
+    assert "0x10000000" in message
+
+
+def test_flash_accepts_sram_and_psram_targets(tmp_path):
+    for address in (0x20000000, 0x11000000):
+        path = tmp_path / f"app_{address:08x}.elf"
+        path.write_bytes(elf([(address, 4096)]))
+        fw.check_flash_elf(path)                       # must not raise
+
+
+def test_flash_catches_a_segment_that_only_overlaps_flash(tmp_path):
+    import pytest
+    # Ends inside the window rather than starting in it.
+    path = tmp_path / "app.elf"
+    path.write_bytes(elf([(0x0FFFFF00, 0x200)]))
+    with pytest.raises(ValueError):
+        fw.check_flash_elf(path)
+
+
+def test_flash_command_is_guarded_by_default(tmp_path, monkeypatch):
+    import pytest
+    root = tmp_path
+    (root / "build" / "apps" / "boom").mkdir(parents=True)
+    (root / "build" / "apps" / "boom" / "boom.elf").write_bytes(
+        elf([(0x10000000, 512)]))
+    monkeypatch.setattr(fw, "REPO_ROOT", root)
+    with pytest.raises(ValueError):
+        fw.flash_command("boom")
+
+
+def test_flash_command_override_allows_firmware_replacement(tmp_path, monkeypatch):
+    root = tmp_path
+    (root / "build" / "apps" / "boom").mkdir(parents=True)
+    (root / "build" / "apps" / "boom" / "boom.elf").write_bytes(
+        elf([(0x10000000, 512)]))
+    monkeypatch.setattr(fw, "REPO_ROOT", root)
+    command = fw.flash_command("boom", replace_display_firmware=True)
+    assert "program build/apps/boom/boom.elf verify reset exit" in command
+
+
+def test_flash_command_without_a_build_still_produces_a_command(tmp_path, monkeypatch):
+    # Nothing built yet: let OpenOCD report the missing file rather than
+    # failing here with a confusing ELF-parse error.
+    monkeypatch.setattr(fw, "REPO_ROOT", tmp_path)
+    command = fw.flash_command("nothing_here")
+    assert any("nothing_here.elf" in part for part in command)


### PR DESCRIPTION
## The incident

An app built from the pre-app-contract template was flashed over the debug probe
repeatedly during a development session. **Every one of those flashes overwrote
the stock DISPLAY firmware**, and nothing in the workflow said so. The board was
never bricked — the recovery loader is fused in OTP — but the firmware was gone
and the first hard evidence was `ioexp: init NAK` / `ft6336: init NO-ACK` at
boot, long after the fact.

## Mechanism

`fw flash` is `openocd -c 'program <elf> verify reset exit'`, which writes each
loadable segment at its **physical** address. For that app:

```
LOAD  VirtAddr 0x20000110   PhysAddr 0x10000210
LOAD  VirtAddr 0x20008c08   PhysAddr 0x10008d04
```

Running addresses in SRAM, **stored** addresses at flash base. That is exactly
what `pico_set_binary_type(copy_to_ram)` produces — the image is copied into
SRAM by the C runtime at boot, but it lives in QSPI flash, which is where the
stock DISPLAY firmware lives.

`fw install-app` has validated UF2 payloads against the DISPLAY memory map for
some time and fails closed before it even mounts the SD card. `fw flash` trusted
the ELF completely. This PR closes that asymmetry.

## The guard

`fw flash` now parses the ELF and refuses by default if any loadable segment
intersects `0x10000000..0x11000000`:

```
fw flash: refusing to program myapp
build/apps/myapp/myapp.elf stores 2 loadable segment(s) in QSPI flash
(0x10000000+512, 0x10000210+35572).
Programming it would REPLACE the stock DISPLAY firmware.
Build the app with fw2_display_app() so it targets SRAM or PSRAM, then
install it non-destructively with `fw install-app <app>.uf2`.
If replacing the DISPLAY firmware is genuinely what you want, re-run
with `fw flash --replace-display-firmware`.
```

Exit status 2, printed rather than raised — a guard that exists to be read
should not bury the actionable part under a traceback. The memory-window
constants are now shared with `check_app_uf2()` so the ELF path and the UF2 path
cannot drift apart.

## Why `fw flash` is not removed or deprecated

Worth being explicit, since "always use `fw install-app`" is the natural
reading. Every app in this tree already uses `fw2_display_app()` (`no_flash`),
so `fw flash` on any of them writes **SRAM only** and is entirely
non-destructive. That path is the fast edit/flash/`fw rtt`/`fw screenshot` loop
the whole agentio workflow runs on, and it needs no SD card, no MAIN firmware,
and no `pyfwfinder`/`pyserial` — none of which `fw install-app` can do without.
Removing it would cost the debug loop and fix nothing that this guard does not
already fix.

The real exposure was never in-tree apps; it is external app repositories and
apps predating the contract — the population least likely to know the hazard
exists, and the population a tool-level guard actually reaches.

## Verification

- Refuses the actual ELF from the incident: four segments at
  `0x10000000+528, 0x10000210+35572, 0x10008d04+13540, 0x1000c1e8+20`.
- Accepts `hello_display` built via `fw2_display_app()`: one segment at
  `0x20000000+28628`, command emitted unchanged.
- `--replace-display-firmware` emits the original command.
- A not-yet-built app still yields the OpenOCD "no such file" error rather than
  a confusing ELF-parse failure.
- `fw test` 45/45, with nine new cases in `tools/tests/test_fw.py`: physical vs
  virtual addressing, NOLOAD segments, a segment that only partially overlaps
  the window, both override paths, and the missing-build case.

Docs updated: `AGENTS.md` command table and the `/apps` contract section,
`README.md` quick start, `docs/app-storage.md`. Findings write-up in
`docs/superpowers/findings/2026-08-07-fw-flash-overwrote-display-firmware.md`.

## Possible follow-up

A configure-time guard — warning when a target links `freewili2_bsp` without
going through `fw2_display_app()` — would catch the same mistake one step
earlier, at build rather than at flash. Left out here to keep this focused on
stopping the destructive write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd92hn7VGig3mxS4efvJ46